### PR TITLE
Add pre-commit hook to ensure license in all `.py` files

### DIFF
--- a/.github/disclaimer.txt
+++ b/.github/disclaimer.txt
@@ -1,0 +1,2 @@
+Copyright (C) 2022 Anaconda, Inc
+SPDX-License-Identifier: BSD-3-Clause

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# This is the configuration for pre-commit, a local framework for managing pre-commit hooks
+#   Check out the docs at: https://pre-commit.com/
+
+exclude: (.*/env/.*)  # Exclude conda environments
+
+repos:
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.13
+    hooks:
+    -   id: insert-license
+        files: \.py$
+        args: [ --license-filepath, .github/disclaimer.txt ]
+        # We exclude the versioneer files, since those are open domain
+        exclude: ^(versioneer.py|conda_project/_version.py)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 import versioneer
 from setuptools import setup, find_packages
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 import pytest
 from functools import partial
 from pathlib import Path


### PR DESCRIPTION
Adds `pre-commit` to ensure that a license disclaimer is placed at the top of every `.py` file automatically.

This will be confirmed by `pre-commit.ci`.