### PR TITLE
Add Codecov to GitHub Action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,10 +80,28 @@ jobs:
         shell: bash
         run: |
           if [ $RUNNER_OS == 'Windows' ]; then
-            source $HOME/miniconda/Scripts/activate root && conda --version && py.test -xv
+            source $HOME/miniconda/Scripts/activate root && \
+            conda --version && \
+            py.test \
+              -xv 
+              --junitxml=./test-reports/junit.xml \
+              --cov-report xml:./test-reports/coverage.xml \
+              --cov conda_project \
+              tests
           else
-            source $HOME/miniconda/bin/activate root && conda --version && py.test -xv
+            source $HOME/miniconda/bin/activate root && \
+            conda --version && \
+            py.test \
+              -xv 
+              --junitxml=./test-reports/junit.xml \
+              --cov-report xml:./test-reports/coverage.xml \
+              --cov conda_project \
+              tests
           fi
+      - uses: codecov/codecov-action@v2
+        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test-reports/coverage.xml
   upload:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,6 +52,9 @@ jobs:
           # Python 3.9
           - conda-version: 4.8
             python-version: 3.9
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - name: Download conda standalone
@@ -100,8 +103,8 @@ jobs:
           fi
       - uses: codecov/codecov-action@v2
         with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./test-reports/coverage.xml
+          env_vars: OS,PYTHON
   upload:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,7 +83,7 @@ jobs:
             source $HOME/miniconda/Scripts/activate root && \
             conda --version && \
             py.test \
-              -xv 
+              -xv \
               --junitxml=./test-reports/junit.xml \
               --cov-report xml:./test-reports/coverage.xml \
               --cov conda_project \
@@ -92,7 +92,7 @@ jobs:
             source $HOME/miniconda/bin/activate root && \
             conda --version && \
             py.test \
-              -xv 
+              -xv \
               --junitxml=./test-reports/junit.xml \
               --cov-report xml:./test-reports/coverage.xml \
               --cov conda_project \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - codecov
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - codecov
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,8 +87,7 @@ jobs:
             conda --version && \
             py.test \
               -xv \
-              --junitxml=./test-reports/junit.xml \
-              --cov-report xml:./test-reports/coverage.xml \
+              --cov-report xml:./coverage.xml \
               --cov conda_project \
               tests
           else
@@ -96,14 +95,13 @@ jobs:
             conda --version && \
             py.test \
               -xv \
-              --junitxml=./test-reports/junit.xml \
-              --cov-report xml:./test-reports/coverage.xml \
+              --cov-report xml:./coverage.xml \
               --cov conda_project \
               tests
           fi
       - uses: codecov/codecov-action@v2
         with:
-          files: ./test-reports/coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON
   upload:
     needs: test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Conda Project
 
+[![codecov](https://codecov.io/gh/conda-incubator/conda-project/branch/main/graph/badge.svg?token=XNRS8JKT75)](https://codecov.io/gh/conda-incubator/conda-project)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/conda-incubator/conda-project/main.svg)](https://results.pre-commit.ci/latest/github/conda-incubator/conda-project/main)
 
 Tool for encapsulating, running, and reproducing projects with Conda environments


### PR DESCRIPTION
Updates the GitHub Action pipeline to report test coverage and publish to [codecov.io](https://app.codecov.io/gh/conda-incubator/conda-project).