### PR TITLE
Add coverage exclusion of lines within `if TYPE_CHECKING:`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ omit =
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,5 @@ omit =
     tests/*
 exclude_lines =
     pragma: no cover
-    if TYPE_CHECKING:
-    if typing.TYPE_CHECKING:
+    # This covers both typing.TYPE_CHECKING and plain TYPE_CHECKING, with any amount of whitespace
+    if\s+(typing\.)?TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,6 @@ omit =
     conda_project/_version.py
     versioneer.py
     tests/*
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:


### PR DESCRIPTION
Small tweak to `.coveragerc` based on this recommendation: https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185

This is to ensure imports used during type checking are not included in the coverage report, since they are never run.