### PR TITLE
Feature: pip support

### DIFF
--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from subprocess import SubprocessError
 from typing import List, Optional, Tuple, Union
 
+from conda_lock._vendor.conda.core.prefix_data import PrefixData
+from conda_lock._vendor.conda.models.records import PackageType
 from conda_lock.conda_lock import (
     default_virtual_package_repodata,
     make_lock_files,
@@ -24,8 +26,6 @@ from conda_lock.conda_lock import (
     parse_conda_lock_file,
     render_lockfile_for_platform,
 )
-from conda_lock.vendor.conda.core.prefix_data import PrefixData
-from conda_lock.vendor.conda.models.records import PackageType
 from pydantic import BaseModel, create_model
 
 from .conda import CONDA_EXE, call_conda, current_platform

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -47,6 +47,13 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=os.environ.get("CONDA_PROJECT_LOGLEVEL", "WARNING"))
 
 
+def _package_type_to_manager(package_type: PackageType) -> str:
+    """Convert a package type to its associated manager, either "conda" or "pip"."""
+    if package_type in PackageType.conda_package_types():
+        return "conda"
+    return "pip"
+
+
 class Environment(BaseModel):
     name: str
     sources: Tuple[Path, ...]
@@ -128,10 +135,9 @@ class Environment(BaseModel):
         # {"conda", "pip"} to allow direct comparison with conda-lock.
         # TODO: Consider comparing more than the name, version, & manager
         # TODO: pip_interop_enabled is marked "DO NOT USE". What is the alternative?
-        manager_map = {PackageType.VIRTUAL_PYTHON_WHEEL: "pip"}
         pd = PrefixData(self.prefix, pip_interop_enabled=True)
         installed_pkgs = {
-            (p.name, p.version, manager_map.get(p.package_type, "conda"))
+            (p.name, p.version, _package_type_to_manager(p.package_type))
             for p in pd.iter_records()
         }
 

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -67,7 +67,7 @@ def _load_pip_sha256_hashes(prefix: str) -> dict[str, str]:
     """
     try:
         pip_freeze = call_conda(["run", "-p", prefix, "pip", "freeze"])
-    except CondaProjectError as e:
+    except CondaProjectError as e:  # pragma: no cover
         if "pip: command not found" in str(e):
             return {}
         else:

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -127,7 +127,7 @@ class Environment(BaseModel):
         manager_map = {PackageType.VIRTUAL_PYTHON_WHEEL: "pip"}
         pd = PrefixData(self.prefix, pip_interop_enabled=True)
         installed_pkgs = {
-            (p.name, p.version, manager_map.get(p.package_type, default="conda"))
+            (p.name, p.version, manager_map.get(p.package_type, "conda"))
             for p in pd.iter_records()
         }
 

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -137,7 +137,7 @@ class Environment(BaseModel):
         # TODO: pip_interop_enabled is marked "DO NOT USE". What is the alternative?
         pd = PrefixData(self.prefix, pip_interop_enabled=True)
         installed_pkgs = {
-            (p.name, p.version, _package_type_to_manager(p.package_type))
+            (p.name, p.version, _package_type_to_manager(p.package_type), p.sha256)
             for p in pd.iter_records()
         }
 
@@ -146,7 +146,7 @@ class Environment(BaseModel):
         # include optional dependencies (e.g. compile/build)
         lock = parse_conda_lock_file(self.lockfile)
         locked_pkgs = {
-            (p.name, p.version, p.manager)
+            (p.name, p.version, p.manager, p.hash.sha256)
             for p in lock.package
             if p.platform == current_platform() and not p.optional
         }

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -119,6 +119,10 @@ class Environment(BaseModel):
         if not self.is_locked:
             return False
 
+        # Here, we ensure that we clear the cache on the PrefixData class. This is to
+        # ensure that we freshly load the installed packages each time.
+        PrefixData._cache_.pop(self.prefix, None)
+
         # Generate a set of (name, version, manager) tuples from the conda environment
         # We also convert the conda package_type attribute to a string in the set
         # {"conda", "pip"} to allow direct comparison with conda-lock.

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -127,7 +127,7 @@ class Environment(BaseModel):
         manager_map = {PackageType.VIRTUAL_PYTHON_WHEEL: "pip"}
         pd = PrefixData(self.prefix, pip_interop_enabled=True)
         installed_pkgs = {
-            (p.name, p.version, manager_map.get(p.package_type, "conda"))
+            (p.name, p.version, manager_map.get(p.package_type, default="conda"))
             for p in pd.iter_records()
         }
 

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -111,25 +111,27 @@ class Environment(BaseModel):
               the environment source and lock files, False otherwise. If is_locked is
               False is_prepared is False.
         """
-        if (self.prefix / "conda-meta" / "history").exists():
-            if self.is_locked:
-                installed_pkgs = call_conda(
-                    ["list", "-p", str(self.prefix), "--explicit"]
-                ).stdout.splitlines()[3:]
+        if not (self.prefix / "conda-meta" / "history").exists():
+            return False
 
-                lock = parse_conda_lock_file(self.lockfile)
-                rendered = render_lockfile_for_platform(
-                    lockfile=lock,
-                    platform=current_platform(),
-                    kind="explicit",
-                    include_dev_dependencies=False,
-                    extras=None,
-                )
-                locked_pkgs = [p.split("#")[0] for p in rendered[3:]]
+        if not self.is_locked:
+            return False
 
-                return installed_pkgs == locked_pkgs
+        installed_pkgs = call_conda(
+            ["list", "-p", str(self.prefix), "--explicit"]
+        ).stdout.splitlines()[3:]
 
-        return False
+        lock = parse_conda_lock_file(self.lockfile)
+        rendered = render_lockfile_for_platform(
+            lockfile=lock,
+            platform=current_platform(),
+            kind="explicit",
+            include_dev_dependencies=False,
+            extras=None,
+        )
+        locked_pkgs = [p.split("#")[0] for p in rendered[3:]]
+
+        return installed_pkgs == locked_pkgs
 
     def lock(
         self,

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - pylint
   - pytest-cov
   - pre-commit
-  - conda-lock>=1
+  - conda-lock>=1.2
   - pydantic
   - ruamel.yaml

--- a/etc/test-environment.yml
+++ b/etc/test-environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - conda-lock>=1
+  - conda-lock>=1.2
   - ruamel.yaml
   - pydantic
   - pytest

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import versioneer
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-requirements = ["conda-lock>=1", "ruamel.yaml", "pydantic"]
+requirements = ["conda-lock>=1.2", "ruamel.yaml", "pydantic"]
 
 setup(
     name="conda-project",

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -244,6 +244,37 @@ def test_is_prepared(project_directory_factory):
 
 
 @pytest.mark.slow
+def test_is_prepared_with_pip_package(project_directory_factory):
+    """Test that we can import the package if it is installed with pip."""
+    env_yaml = dedent(
+        """\
+        name: test
+        dependencies:
+          - python=3.8
+          - pip
+          - pip:
+            - requests
+        """
+    )
+    project_path = project_directory_factory(env_yaml=env_yaml)
+    project = CondaProject(project_path)
+
+    _ = project.default_environment.prepare()
+
+    # This assertion won't pass if there are pip packages
+    # assert project.default_environment.is_prepared
+
+    args = [
+        "run",
+        *("-p", str(project.environments["default"].prefix)),
+        "python",
+        *("-c", "import requests"),
+    ]
+    result = call_conda(args, condarc_path=project.condarc)
+    assert result.returncode == 0
+
+
+@pytest.mark.slow
 def test_is_prepared_live_env_changed(project_directory_factory, capsys):
     env_yaml = dedent(
         """\

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -264,15 +264,6 @@ def test_is_prepared_with_pip_package(project_directory_factory):
     # This assertion won't pass if there are pip packages
     assert project.default_environment.is_prepared
 
-    args = [
-        "run",
-        *("-p", str(project.environments["default"].prefix)),
-        "python",
-        *("-c", "import requests"),
-    ]
-    result = call_conda(args, condarc_path=project.condarc)
-    assert result.returncode == 0
-
 
 @pytest.mark.slow
 def test_is_prepared_live_env_changed(project_directory_factory, capsys):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -264,6 +264,15 @@ def test_is_prepared_with_pip_package(project_directory_factory):
     # This assertion won't pass if there are pip packages
     assert project.default_environment.is_prepared
 
+    args = [
+        "run",
+        *("-p", str(project.environments["default"].prefix)),
+        "python",
+        *("-c", "import requests"),
+    ]
+    result = call_conda(args, condarc_path=project.condarc)
+    assert result.returncode == 0
+
 
 @pytest.mark.slow
 def test_is_prepared_live_env_changed(project_directory_factory, capsys):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -262,7 +262,7 @@ def test_is_prepared_with_pip_package(project_directory_factory):
     _ = project.default_environment.prepare()
 
     # This assertion won't pass if there are pip packages
-    # assert project.default_environment.is_prepared
+    assert project.default_environment.is_prepared
 
     args = [
         "run",


### PR DESCRIPTION
Adds support for `pip` dependencies. For this, we take the same approach as `conda-lock`.

In addition, I have modified the logic of `Environment.is_prepared` to do a more robust comparison of packages installed vs. specified in the lock file.