### PR TITLE
Use optional indirect fixtures to prevent running tests twice

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,20 @@ from typing import Optional
 import pytest
 
 
-@pytest.fixture(params=[".yml", ".yaml"])
+@pytest.fixture()
 def project_directory_factory(tmp_path, request):
-    """A fixture returning a factory function used to create a temporary project directory."""
+    """A fixture returning a factory function used to create a temporary project directory.
+
+    By default, it will create YAML files with the `.yml` extension. f another test needs
+    additional extensions, add a parameterization decorator like:
+
+        @pytest.mark.parametrize('project_directory_factory', ['.yml', '.yaml'], indirect=True)
+        def test_something(project_directory_factory):
+            ...
+
+    """
+
+    suffix = getattr(request, "param", ".yml")
 
     def create_project_directory(
         env_yaml: Optional[str] = None,
@@ -30,7 +41,6 @@ def project_directory_factory(tmp_path, request):
             A path to the temporary project directory.
 
         """
-        suffix = request.param
         if env_yaml is not None:
             env_file = (tmp_path / "environment").with_suffix(suffix)
             with env_file.open("w") as f:
@@ -50,6 +60,6 @@ def project_directory_factory(tmp_path, request):
 
         return tmp_path
 
-    create_project_directory._suffix = request.param
+    create_project_directory._suffix = suffix
 
     return create_project_directory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 def project_directory_factory(tmp_path, request):
     """A fixture returning a factory function used to create a temporary project directory.
 
-    By default, it will create YAML files with the `.yml` extension. f another test needs
+    By default, it will create YAML files with the `.yml` extension. If another test needs
     additional extensions, add a parameterization decorator like:
 
         @pytest.mark.parametrize('project_directory_factory', ['.yml', '.yaml'], indirect=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ def test_command_args(command, monkeypatch, capsys):
 
 
 @pytest.mark.parametrize("command", ENVIRONMENT_COMMANDS)
+@pytest.mark.parametrize("project_directory_factory", [".yml", ".yaml"], indirect=True)
 def test_cli_verbose_env(command, monkeypatch, project_directory_factory):
     if command == "create":
         project_path = project_directory_factory()


### PR DESCRIPTION
Uses `pytest` [indirect parametrization](https://docs.pytest.org/en/7.1.x/example/parametrize.html?#indirect-parametrization) to reduce the number of duplicated tests. This allows us to run roughly half the tests but still optionally run specific tests with multiple file extensions.