### PR TITLE
Change naming syntax for lockfiles and references in the documentation

### DIFF
--- a/conda_project/cli/main.py
+++ b/conda_project/cli/main.py
@@ -99,7 +99,9 @@ def _create_create_parser(
         default=None,
     )
     p.add_argument(
-        "--no-lock", help="Do not create the conda-lock.yml file", action="store_true"
+        "--no-lock",
+        help="Do not create the conda-lock.<env>.yml file(s)",
+        action="store_true",
     )
     p.add_argument(
         "--prepare",
@@ -130,7 +132,7 @@ def _create_lock_parser(
         parent_parser: The parent parser, which is used to pass common arguments into the subcommands.
 
     """
-    desc = "Lock all conda environments or a specific one by creating .conda-lock.yml files."
+    desc = "Lock all conda environments or a specific one by creating conda-lock.<env>.yml file(s)."
 
     p = subparsers.add_parser(
         "lock", description=desc, help=desc, parents=[parent_parser]
@@ -143,7 +145,7 @@ def _create_lock_parser(
     )
     p.add_argument(
         "--force",
-        help="Remove and recreate existing .conda-lock.yml files.",
+        help="Remove and recreate existing conda-lock.<env>.yml file(s).",
         action="store_true",
     )
 
@@ -161,7 +163,7 @@ def _create_check_parser(
 
     """
     desc = (
-        "Check the project for inconsistencies or errors. This will check that .conda-lock.yml files "
+        "Check the project for inconsistencies or errors. This will check that conda-lock.<env>.yml file(s) "
         "have been created for each environment and are up-to-date with the source environment specifications. "
         "If the project is fully locked this command will not print anything and return status code 0. If any "
         "environment is not fully locked details are printed to stderr and the command returns status code 1."

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -439,10 +439,10 @@ class Environment(BaseModel):
     ) -> None:
         """Generate locked package lists for the supplied or default platforms
 
-        Utilizes conda-lock to build the .conda-lock.yml file.
+        Utilizes conda-lock to build the conda-lock.<env>.yml file(s).
 
         Args:
-            force:       Rebuild the .conda-lock.yml file even if no changes were made
+            force:       Rebuild the conda-lock.<env>.yml file even if no changes were made
                          to the dependencies.
             verbose:     A verbose flag passed into the `conda lock` command.
 
@@ -522,8 +522,8 @@ class Environment(BaseModel):
         """Prepare the conda environment.
 
         Creates a new conda environment and installs the packages from the environment.yaml file.
-        Environments are always created from the conda-lock.yml file. The conda-lock.yml
-        will be created if it does not already exist.
+        Environments are always created from the conda-lock.<env>.yml file(s). The conda-lock.<env>.yml file(s)
+        will be created if they do not already exist.
 
         Args:
             force: If True, will force creation of a new conda environment.

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -162,7 +162,7 @@ class CondaProject:
                                included.
             conda_configs:     List of conda configuration parameters to include in the .condarc file
                                written to the project directory.
-            lock_dependencies: Create the conda-lock.yml file for the requested dependencies.
+            lock_dependencies: Create the conda-lock.<env>.yml file(s) for the requested dependencies.
                                Default is True.
             force:             Force creation of project and environment files if they already
                                exist. The default value is False.
@@ -228,7 +228,7 @@ class CondaProject:
                 name=env_name,
                 sources=tuple([self.directory / str(s) for s in sources]),
                 prefix=self.directory / "envs" / env_name,
-                lockfile=self.directory / f"{env_name}.conda-lock.yml",
+                lockfile=self.directory / f"conda-lock.{env_name}.yml",
                 project=weakref.proxy(self),
             )
         Environments = create_model(
@@ -283,7 +283,7 @@ class CondaProject:
     def check(self, verbose=False) -> bool:
         """Check the project for inconsistencies or errors.
 
-        This will check that .conda-lock.yml files exist for each environment
+        This will check that conda-lock.<env>.yml file(s) exist for each environment
         and that they are up-to-date against the environment specification.
 
         Returns:

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -3,7 +3,7 @@
 ## Creating a new project
 
 The purpose of `conda project create` is to provide a command like `conda create` that creates the
-`environment.yml`, `conda-project.yml` and `default.conda-lock.yml` files before installing the
+`environment.yml`, `conda-project.yml` and `conda-lock.default.yml` files before installing the
 environment.
 The `--prepare` flag can be used to build the files and then install the environment.
 
@@ -50,7 +50,7 @@ optional arguments:
   --conda-configs CONDA_CONFIGS
                         Comma separated list of conda configuration parameters to write into the .condarc file in the project directory. The
                         format for each config is key=value. For example --conda-configs experimental_solver=libmamba,channel_priority=strict
-  --no-lock             Do no create the conda-lock.yml file
+  --no-lock             Do no create the conda-lock.<env>.yml file(s)
   --prepare             Create the local conda environment for the current platform.
 ```
 
@@ -117,9 +117,9 @@ To force a re-lock use `conda project lock --force`.
 ## Preparing your environments
 
 `conda project prepare` enforces the use of `conda-lock`.
-If a `.conda-lock.yml` file is not present it will be created by prepare with the above
+If a `conda-lock.<env>.yml` file is not present it will be created by prepare with the above
 assumptions  if necessary.
-If a `.conda-lock.yml` file is found but the locked platforms do not match your current platform
+If a `conda-lock.<env>.yml` file is found but the locked platforms do not match your current platform
 it will raise an exception.
 
 The live conda environment is built from a rendered lockfile (explicit type) for your current
@@ -145,7 +145,7 @@ Project created at /Users/adefusco/Development/conda-incubator/conda-project/exa
 ./
 ├── .condarc
 ├── conda-project.yml
-├── default.conda-lock.yml
+├── conda-lock.default.yml
 └── environment.yml
 
 ❯ cat environment.yml

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -117,7 +117,7 @@ def test_project_create_and_lock(tmp_path):
         tmp_path, dependencies=["python=3.8"], lock_dependencies=True
     )
     assert p.default_environment.lockfile.exists()
-    assert p.default_environment.lockfile == tmp_path / "default.conda-lock.yml"
+    assert p.default_environment.lockfile == tmp_path / "conda-lock.default.yml"
 
 
 def test_conda_project_init_empty_dir(tmp_path, caplog):
@@ -146,7 +146,7 @@ def test_conda_project_init_with_env_yaml(project_directory_factory):
 
     assert (
         project.default_environment.lockfile
-        == project.directory / "default.conda-lock.yml"
+        == project.directory / "conda-lock.default.yml"
     )
     assert project.default_environment.sources == (
         (project.directory / "environment").with_suffix(
@@ -399,7 +399,7 @@ def test_lock(project_directory_factory):
     project = CondaProject(project_path)
     project.default_environment.lock()
 
-    lockfile = project_path / "default.conda-lock.yml"
+    lockfile = project_path / "conda-lock.default.yml"
     assert lockfile == project.default_environment.lockfile
     assert lockfile.exists()
     assert project.default_environment.is_locked
@@ -553,7 +553,7 @@ def test_force_relock(project_directory_factory, capsys):
     project.default_environment.lock(verbose=True)
     stdout = capsys.readouterr().out
     assert (
-        "The lockfile default.conda-lock.yml already exists and is up-to-date."
+        "The lockfile conda-lock.default.yml already exists and is up-to-date."
         in stdout
     )
     assert lockfile_mtime == os.path.getmtime(project.default_environment.lockfile)
@@ -822,7 +822,7 @@ def test_prepare_named_environment(project_directory_factory):
     env_dir = project.default_environment.prepare()
 
     assert project.environments["standard"].lockfile.samefile(
-        project_path / "standard.conda-lock.yml"
+        project_path / "conda-lock.standard.yml"
     )
     assert project.environments["standard"].prefix.samefile(
         project_path / "envs" / "standard"
@@ -913,7 +913,7 @@ def test_lock_prepare_clean_default_with_multiple_envs(project_directory_factory
     project.default_environment.prepare()
 
     assert project.default_environment.lockfile.samefile(
-        project_path / "bbb.conda-lock.yml"
+        project_path / "conda-lock.bbb.yml"
     )
     assert project.default_environment.lockfile.exists()
 
@@ -948,7 +948,7 @@ def test_lock_prepare_clean_named_with_multiple_envs(project_directory_factory):
     project.environments["default"].prepare()
 
     assert project.environments["default"].lockfile.samefile(
-        project_path / "default.conda-lock.yml"
+        project_path / "conda-lock.default.yml"
     )
     assert project.environments["default"].lockfile.exists()
 
@@ -986,7 +986,7 @@ def test_lock_prepare_clean_multiple_envs(project_directory_factory):
     project.environments["bbb"].prepare()
 
     assert project.environments["bbb"].lockfile.samefile(
-        project_path / "bbb.conda-lock.yml"
+        project_path / "conda-lock.bbb.yml"
     )
     assert project.environments["bbb"].lockfile.exists()
 
@@ -997,7 +997,7 @@ def test_lock_prepare_clean_multiple_envs(project_directory_factory):
     project.environments["default"].prepare()
 
     assert project.environments["default"].lockfile.samefile(
-        project_path / "default.conda-lock.yml"
+        project_path / "conda-lock.default.yml"
     )
     assert project.environments["default"].lockfile.exists()
 


### PR DESCRIPTION
Changed the naming convention for lockfiles.

Instead of prefixing with the environment, this PR changes to the format `conda-lock.<env_name>.yml`, which enables lexographic sorting in a standard file browser. It also enables easier build deletion of lockfiles.

Addresses #57.