### PR TITLE
feat: Rename CLI subcommands `create` -> `init` and `prepare` -> `install`, and add aliases

### DIFF
--- a/conda_project/cli/commands.py
+++ b/conda_project/cli/commands.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+import logging
 import sys
 from argparse import Namespace
 from functools import wraps
@@ -8,6 +9,8 @@ from typing import Any, Callable, NoReturn
 
 from ..exceptions import CommandNotFoundError, CondaProjectError
 from ..project import Command, CondaProject
+
+logger = logging.getLogger(__name__)
 
 
 def handle_errors(func: Callable[[Namespace], Any]) -> Callable[[Namespace], int]:
@@ -29,7 +32,7 @@ def handle_errors(func: Callable[[Namespace], Any]) -> Callable[[Namespace], int
 
 
 @handle_errors
-def create(args: Namespace) -> bool:
+def init(args: Namespace) -> bool:
     project = CondaProject.create(
         args.directory,
         args.name,
@@ -45,6 +48,13 @@ def create(args: Namespace) -> bool:
         project.default_environment.prepare(verbose=True)
 
     return True
+
+
+def create(args: Namespace) -> int:
+    logger.warning(
+        "The 'create' subcommand is an alias for 'init' and may be removed in a future version."
+    )
+    return init(args)
 
 
 @handle_errors

--- a/conda_project/cli/commands.py
+++ b/conda_project/cli/commands.py
@@ -44,7 +44,7 @@ def init(args: Namespace) -> bool:
         verbose=True,
     )
 
-    if args.prepare:
+    if args.install:
         project.default_environment.prepare(verbose=True)
 
     return True

--- a/conda_project/cli/commands.py
+++ b/conda_project/cli/commands.py
@@ -33,14 +33,16 @@ def handle_errors(func: Callable[[Namespace], Any]) -> Callable[[Namespace], int
 
 @handle_errors
 def init(args: Namespace) -> bool:
-    project = CondaProject.create(
-        args.directory,
-        args.name,
-        args.dependencies,
-        args.channel,
-        args.platforms.split(","),
-        [] if args.conda_configs is None else args.conda_configs.split(","),
-        not args.no_lock,
+    project = CondaProject.init(
+        directory=args.directory,
+        name=args.name,
+        dependencies=args.dependencies,
+        channels=args.channel,
+        platforms=args.platforms.split(","),
+        conda_configs=[]
+        if args.conda_configs is None
+        else args.conda_configs.split(","),
+        lock_dependencies=not args.no_lock,
         verbose=True,
     )
 

--- a/conda_project/cli/commands.py
+++ b/conda_project/cli/commands.py
@@ -79,7 +79,7 @@ def check(args: Namespace) -> bool:
 
 
 @handle_errors
-def prepare(args: Namespace) -> bool:
+def install(args: Namespace) -> bool:
     project = CondaProject(args.directory)
 
     if args.all:
@@ -94,6 +94,13 @@ def prepare(args: Namespace) -> bool:
         env.prepare(force=args.force, as_platform=args.as_platform, verbose=True)
 
     return True
+
+
+def prepare(args: Namespace) -> int:
+    logger.warning(
+        "The 'prepare' subcommand is an alias for 'install' and may be removed in a future version."
+    )
+    return install(args)
 
 
 @handle_errors

--- a/conda_project/cli/commands.py
+++ b/conda_project/cli/commands.py
@@ -47,7 +47,7 @@ def init(args: Namespace) -> bool:
     )
 
     if args.install:
-        project.default_environment.prepare(verbose=True)
+        project.default_environment.install(verbose=True)
 
     return True
 
@@ -86,14 +86,14 @@ def install(args: Namespace) -> bool:
 
     if args.all:
         for _, env in project.environments:
-            env.prepare(force=args.force, verbose=True)
+            env.install(force=args.force, verbose=True)
     else:
         env = (
             project.environments[args.environment]
             if args.environment
             else project.default_environment
         )
-        env.prepare(force=args.force, as_platform=args.as_platform, verbose=True)
+        env.install(force=args.force, as_platform=args.as_platform, verbose=True)
 
     return True
 

--- a/conda_project/cli/main.py
+++ b/conda_project/cli/main.py
@@ -106,7 +106,7 @@ def _create_init_parser(
             action="store_true",
         )
         p.add_argument(
-            "--prepare",
+            "--install",
             help="Create the local conda environment for the current platform.",
             action="store_true",
         )

--- a/conda_project/cli/main.py
+++ b/conda_project/cli/main.py
@@ -44,7 +44,7 @@ def cli() -> ArgumentParser:
     _create_init_parser(subparsers, common)
     _create_lock_parser(subparsers, common)
     _create_check_parser(subparsers, common)
-    _create_prepare_parser(subparsers, common)
+    _create_install_parser(subparsers, common)
     _create_activate_parser(subparsers, common)
     _create_clean_parser(subparsers, common)
     _create_run_parser(subparsers, common)
@@ -126,7 +126,9 @@ def _create_init_parser(
         elif subcommand_name == "create":
             p.set_defaults(func=commands.create)
         else:
-            raise ValueError("Unknown subcommand (this should be unreachable)")
+            raise ValueError(
+                f"Unknown subcommand: {subcommand_name} (this should be unreachable)"
+            )
 
 
 def _create_lock_parser(
@@ -183,52 +185,62 @@ def _create_check_parser(
     p.set_defaults(func=commands.check)
 
 
-def _create_prepare_parser(
+def _create_install_parser(
     subparsers: "_SubParsersAction", parent_parser: ArgumentParser
 ) -> None:
-    """Add a subparser for the "prepare" subcommand.
+    """Add a subparser for the "install" and "prepare" subcommands.
 
     Args:
         subparsers: The existing subparsers corresponding to the "command" meta-variable.
         parent_parser: The parent parser, which is used to pass common arguments into the subcommands.
 
     """
-    desc = "Prepare the conda environments"
+    desc = "Install the packages into the conda environments"
 
-    p = subparsers.add_parser(
-        "prepare", description=desc, help=desc, parents=[parent_parser]
-    )
-    group = p.add_mutually_exclusive_group(required=False)
-    group.add_argument(
-        "environment",
-        help="Prepare the selected environment. If no environment name is selected "
-        "the first environment defined in the conda-project.yml file is prepared.",
-        nargs="?",
-    )
-    group.add_argument(
-        "--as-platform",
-        help="Prepare the conda environment assuming a different platform/subdir name.",
-        action="store",
-        metavar="PLATFORM",
-    )
-    group.add_argument(
-        "--all", help="Check or prepare all defined environments.", action="store_true"
-    )
-    p.add_argument(
-        "--check-only",
-        help="Check that the prepared conda environment exists and is up-to-date with the "
-        "source environment and files and lockfile and then exit. If the environment is up-to-date "
-        "nothing is printed and the command exists with 0. If the environment is missing or out-of-date "
-        "details are printed to stderr and the command exits with 1.",
-        action="store_true",
-    )
-    p.add_argument(
-        "--force",
-        help="Remove and recreate an existing environment.",
-        action="store_true",
-    )
+    for subcommand_name in ["install", "prepare"]:
+        p = subparsers.add_parser(
+            subcommand_name, description=desc, help=desc, parents=[parent_parser]
+        )
+        group = p.add_mutually_exclusive_group(required=False)
+        group.add_argument(
+            "environment",
+            help="Prepare the selected environment. If no environment name is selected "
+            "the first environment defined in the conda-project.yml file is prepared.",
+            nargs="?",
+        )
+        group.add_argument(
+            "--as-platform",
+            help="Prepare the conda environment assuming a different platform/subdir name.",
+            action="store",
+            metavar="PLATFORM",
+        )
+        group.add_argument(
+            "--all",
+            help="Check or prepare all defined environments.",
+            action="store_true",
+        )
+        p.add_argument(
+            "--check-only",
+            help="Check that the prepared conda environment exists and is up-to-date with the "
+            "source environment and files and lockfile and then exit. If the environment is up-to-date "
+            "nothing is printed and the command exists with 0. If the environment is missing or out-of-date "
+            "details are printed to stderr and the command exits with 1.",
+            action="store_true",
+        )
+        p.add_argument(
+            "--force",
+            help="Remove and recreate an existing environment.",
+            action="store_true",
+        )
 
-    p.set_defaults(func=commands.prepare)
+        if subcommand_name == "install":
+            p.set_defaults(func=commands.install)
+        elif subcommand_name == "prepare":
+            p.set_defaults(func=commands.prepare)
+        else:
+            raise ValueError(
+                f"Unknown subcommand: {subcommand_name} (this should be unreachable)"
+            )
 
 
 def _create_clean_parser(

--- a/conda_project/cli/main.py
+++ b/conda_project/cli/main.py
@@ -121,14 +121,7 @@ def _create_init_parser(
             metavar="PACKAGE_SPECIFICATION",
         )
 
-        if subcommand_name == "init":
-            p.set_defaults(func=commands.init)
-        elif subcommand_name == "create":
-            p.set_defaults(func=commands.create)
-        else:
-            raise ValueError(
-                f"Unknown subcommand: {subcommand_name} (this should be unreachable)"
-            )
+        p.set_defaults(func=getattr(commands, subcommand_name))
 
 
 def _create_lock_parser(
@@ -233,14 +226,7 @@ def _create_install_parser(
             action="store_true",
         )
 
-        if subcommand_name == "install":
-            p.set_defaults(func=commands.install)
-        elif subcommand_name == "prepare":
-            p.set_defaults(func=commands.prepare)
-        else:
-            raise ValueError(
-                f"Unknown subcommand: {subcommand_name} (this should be unreachable)"
-            )
+        p.set_defaults(func=getattr(commands, subcommand_name))
 
 
 def _create_clean_parser(

--- a/conda_project/cli/main.py
+++ b/conda_project/cli/main.py
@@ -41,7 +41,7 @@ def cli() -> ArgumentParser:
 
     subparsers = p.add_subparsers(metavar="command", required=True)
 
-    _create_create_parser(subparsers, common)
+    _create_init_parser(subparsers, common)
     _create_lock_parser(subparsers, common)
     _create_check_parser(subparsers, common)
     _create_prepare_parser(subparsers, common)
@@ -52,74 +52,81 @@ def cli() -> ArgumentParser:
     return p
 
 
-def _create_create_parser(
+def _create_init_parser(
     subparsers: "_SubParsersAction", parent_parser: ArgumentParser
 ) -> None:
-    """Add a subparser for the "create" subcommand.
+    """Add a subparser for the "init" and "create" subcommands.
 
     Args:
         subparsers: The existing subparsers corresponding to the "command" meta-variable.
         parent_parser: The parent parser, which is used to pass common arguments into the subcommands.
 
     """
-    desc = "Create a new project"
+    desc = "Initialize a new project"
 
-    p = subparsers.add_parser(
-        "create", description=desc, help=desc, parents=[parent_parser]
-    )
-    p.add_argument(
-        "-n", "--name", help="Name for the project.", action="store", default=None
-    )
-    p.add_argument(
-        "-c",
-        "--channel",
-        help=(
-            "Additional channel to search for packages. The default channel is 'defaults'. "
-            "Multiple channels are added with repeated use of this argument."
-        ),
-        action="append",
-    )
-    p.add_argument(
-        "--platforms",
-        help=(
-            f"Comma separated list of platforms for which to lock dependencies. "
-            f"The default is {','.join(DEFAULT_PLATFORMS)}"
-        ),
-        action="store",
-        default=",".join(DEFAULT_PLATFORMS),
-    )
-    p.add_argument(
-        "--conda-configs",
-        help=(
-            "Comma separated list of conda configuration parameters to write into the "
-            ".condarc file in the project directory. The format for each config is key=value. "
-            "For example --conda-configs experimental_solver=libmamba,channel_priority=strict"
-        ),
-        action="store",
-        default=None,
-    )
-    p.add_argument(
-        "--no-lock",
-        help="Do not create the conda-lock.<env>.yml file(s)",
-        action="store_true",
-    )
-    p.add_argument(
-        "--prepare",
-        help="Create the local conda environment for the current platform.",
-        action="store_true",
-    )
-    p.add_argument(
-        "dependencies",
-        help=(
-            "Packages to add to the environment.yml. The format for each package is '<name>[<op><version>]' "
-            "where <op> can be =, <, >, <=, or >=."
-        ),
-        action="store",
-        nargs="*",
-        metavar="PACKAGE_SPECIFICATION",
-    )
+    # TODO: If we deprecate "create", this loop can go away.
+    for subcommand_name in ["init", "create"]:
+        p = subparsers.add_parser(
+            subcommand_name, description=desc, help=desc, parents=[parent_parser]
+        )
+        p.add_argument(
+            "-n", "--name", help="Name for the project.", action="store", default=None
+        )
+        p.add_argument(
+            "-c",
+            "--channel",
+            help=(
+                "Additional channel to search for packages. The default channel is 'defaults'. "
+                "Multiple channels are added with repeated use of this argument."
+            ),
+            action="append",
+        )
+        p.add_argument(
+            "--platforms",
+            help=(
+                f"Comma separated list of platforms for which to lock dependencies. "
+                f"The default is {','.join(DEFAULT_PLATFORMS)}"
+            ),
+            action="store",
+            default=",".join(DEFAULT_PLATFORMS),
+        )
+        p.add_argument(
+            "--conda-configs",
+            help=(
+                "Comma separated list of conda configuration parameters to write into the "
+                ".condarc file in the project directory. The format for each config is key=value. "
+                "For example --conda-configs experimental_solver=libmamba,channel_priority=strict"
+            ),
+            action="store",
+            default=None,
+        )
+        p.add_argument(
+            "--no-lock",
+            help="Do not create the conda-lock.<env>.yml file(s)",
+            action="store_true",
+        )
+        p.add_argument(
+            "--prepare",
+            help="Create the local conda environment for the current platform.",
+            action="store_true",
+        )
+        p.add_argument(
+            "dependencies",
+            help=(
+                "Packages to add to the environment.yml. The format for each package is '<name>[<op><version>]' "
+                "where <op> can be =, <, >, <=, or >=."
+            ),
+            action="store",
+            nargs="*",
+            metavar="PACKAGE_SPECIFICATION",
+        )
 
-    p.set_defaults(func=commands.create)
+        if subcommand_name == "init":
+            p.set_defaults(func=commands.init)
+        elif subcommand_name == "create":
+            p.set_defaults(func=commands.create)
+        else:
+            raise ValueError("Unknown subcommand (this should be unreachable)")
 
 
 def _create_lock_parser(

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -511,13 +511,13 @@ class Environment(BaseModel):
         msg = f"Locked dependencies for {', '.join(lock.metadata.platforms)} platforms"
         logger.info(msg)
 
-    def prepare(
+    def install(
         self,
         force: bool = False,
         as_platform: Optional[str] = None,
         verbose: bool = False,
     ) -> Path:
-        """Prepare the conda environment.
+        """Install all dependencies into the conda environment.
 
         Creates a new conda environment and installs the packages from the environment.yaml file.
         Environments are always created from the conda-lock.<env>.yml file(s). The conda-lock.<env>.yml file(s)
@@ -525,6 +525,8 @@ class Environment(BaseModel):
 
         Args:
             force: If True, will force creation of a new conda environment.
+            as_platform: Install dependencies as an explicit platform. By default, the
+                platform will be identified for the system.
             verbose: A verbose flag passed into the `conda create` command.
 
         Raises:
@@ -668,7 +670,7 @@ class Environment(BaseModel):
 
     def activate(self, verbose=False) -> None:
         if not self.is_prepared:
-            self.prepare(verbose=verbose)
+            self.install(verbose=verbose)
 
         env = prepare_variables(
             self.project.directory, self.project._project_file.variables
@@ -709,7 +711,7 @@ class Command(BaseModel):
                 environment = self.project.environments[environment]
 
         if not environment.is_prepared:
-            environment.prepare(verbose=verbose)
+            environment.install(verbose=verbose)
 
         env = prepare_variables(
             self.project.directory,

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -131,7 +131,7 @@ class CondaProject:
         self.condarc = self.directory / ".condarc"
 
     @classmethod
-    def create(
+    def init(
         cls,
         directory: Union[Path, str] = ".",
         name: Optional[str] = None,
@@ -142,7 +142,7 @@ class CondaProject:
         lock_dependencies: bool = True,
         verbose: bool = False,
     ) -> CondaProject:
-        """Create a new project
+        """Initialize a new project.
 
         Creates the environment.yml file from the specified dependencies,
         channels, and platforms. Further a local .condarc can also be
@@ -164,8 +164,6 @@ class CondaProject:
                                written to the project directory.
             lock_dependencies: Create the conda-lock.<env>.yml file(s) for the requested dependencies.
                                Default is True.
-            force:             Force creation of project and environment files if they already
-                               exist. The default value is False.
             verbose:           Print information to stdout. The default value is False.
 
         Returns:

--- a/conda_project/project.py
+++ b/conda_project/project.py
@@ -382,7 +382,7 @@ class Environment(BaseModel):
             return False
 
     @property
-    def is_prepared(self) -> bool:
+    def is_consistent(self) -> bool:
         """
         bool: Returns True if the conda environment exists and is consistent with
               the environment source and lock files, False otherwise. If is_locked is
@@ -541,7 +541,7 @@ class Environment(BaseModel):
                 print(f"The lockfile {self.lockfile} is out-of-date, re-locking...")
             self.lock(verbose=verbose)
 
-        if self.is_prepared:
+        if self.is_consistent:
             if not force:
                 logger.info(f"environment already exists at {self.prefix}")
                 if verbose:
@@ -550,7 +550,9 @@ class Environment(BaseModel):
                         f"run 'conda project prepare --force {self.name} to recreate it from the locked dependencies."
                     )
                 return self.prefix
-        elif (self.prefix / "conda-meta" / "history").exists() and not self.is_prepared:
+        elif (
+            self.prefix / "conda-meta" / "history"
+        ).exists() and not self.is_consistent:
             if not force:
                 if verbose:
                     print(
@@ -669,7 +671,7 @@ class Environment(BaseModel):
         )
 
     def activate(self, verbose=False) -> None:
-        if not self.is_prepared:
+        if not self.is_consistent:
             self.install(verbose=verbose)
 
         env = prepare_variables(
@@ -710,7 +712,7 @@ class Command(BaseModel):
             if isinstance(environment, str):
                 environment = self.project.environments[environment]
 
-        if not environment.is_prepared:
+        if not environment.is_consistent:
             environment.install(verbose=verbose)
 
         env = prepare_variables(

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -12,13 +12,13 @@ If `conda-project` is not yet installed and started Project, follow the [Install
 
 ## Create a new project
 
-This section of the tutorial explores the `create` and `activate` subcommands of conda-project.
+This section of the tutorial explores the `init` and `activate` subcommands of conda-project.
 
 1. Open a Command Prompt or terminal window.
 
 2. Initialize the project in a new directory:
    ```shell
-   conda-project create -n learn-cp --directory cp-tutorial --platform osx-arm64,linux-64 -c defaults -c conda-forge \
+   conda-project init -n learn-cp --directory cp-tutorial --platform osx-arm64,linux-64 -c defaults -c conda-forge \
        python=3.10 notebook r-essentials r-plotly r-shiny
    ```
 
@@ -28,7 +28,7 @@ This section of the tutorial explores the `create` and `activate` subcommands of
    calculated across **conda-project**'s default list of platform architectures.
 
    ```{note}
-   This tutorial issues the `create` action for a new project.  As noted in the [User Guide](user_guide), it is also possible
+   This tutorial issues the `init` action for a new project.  As noted in the [User Guide](user_guide), it is also possible
    to create a project from an existing environment file.
 
    If using windows, change the `--platform` argument to point to the correct architecture (win-64).
@@ -71,25 +71,25 @@ This section of the tutorial explores the `create` and `activate` subcommands of
    commands: {}
    ```
 
-   Note that the `name` key is populated with the value supplied in the `create` action.
+   Note that the `name` key is populated with the value supplied in the `init` action.
 
    An upcoming section of the tutorial will involve adding a custom command to the `commands` key. It's also
    possible to define variables using the `variables` key.  These key varlue pairs are loaded as overrides
    to the inherited execution environment when a `run` action is issued.
 
-6. Initiate the `prepare` action on the project:
+6. Initiate the `install` action on the project:
    ```shell
-   $ conda-project prepare
+   $ conda-project install
    ```
 
    ```{note}
-   As noted in a [preceding section](user_guide), the `prepare` action will initiate conda install
+   As noted in a [preceding section](user_guide), the `install` action will initiate conda install
    for the active environment.
    ```
 
    ```{note}
-   Running the prepare step is not strictly required. Calling the `run` command such as the one included
-   in the next section, will result in `prepare` being called automatically.
+   Running the install step is not strictly required. Calling the `run` command such as the one included
+   in the next section, will result in `install` being called automatically.
    ```
 
 ## Create an example notebook-based shiny app

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -368,12 +368,12 @@ from conda_project import CondaProject
 
 project = CondaProject()
 project.default_environment.lock()
-prefix = project.default_environment.prepare()
+prefix = project.default_environment.install()
 
 ## alternative, use the name 'default'
 
 project.environments['default'].lock()
-prefix = project.environments['default'].prepare()
+prefix = project.environments['default'].install()
 ```
 
 To create a new project directory the `CondaProject.create()` method follows the CLI arguments

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -1,38 +1,38 @@
 # User Guide
 
-## Creating a new project
+## Initializing a new project
 
-The purpose of `conda project create` is to provide a command like `conda create` that creates the
+The purpose of `conda project init` is to provide a command like `conda create` that creates the
 `environment.yml`, `conda-project.yml` and `conda-lock.default.yml` files before installing the
 environment.
-The `--prepare` flag can be used to build the files and then install the environment.
+The `--install` flag can be used to build the files and then install the environment.
 
-The create command will always write `channels` and `platforms` into the environment.yml file.
+The init command will always write `channels` and `platforms` into the environment.yml file.
 
 From within an existing project directory, run:
 
 ```shell
-conda project create
+conda project init
 ```
 
 Packages can also be specified when creating a project:
 
 ```shell
-conda project create python=3.10
+conda project init python=3.10
 ```
 
 This will initialize your project with a new `conda-project.yml`, `environment.yml`, and local `.condarc` file.
 
 ### CLI help
 
-The following is the output of `conda project create --help`:
+The following is the output of `conda project init --help`:
 
 ```text
-usage: conda-project create [-h] [--directory PROJECT_DIR] [-n NAME] [-c CHANNEL] [--platforms PLATFORMS] [--conda-configs CONDA_CONFIGS]
-                            [--no-lock] [--prepare]
+usage: conda-project init [-h] [--directory PROJECT_DIR] [-n NAME] [-c CHANNEL] [--platforms PLATFORMS] [--conda-configs CONDA_CONFIGS]
+                            [--no-lock] [--install]
                             [dependencies [dependencies ...]]
 
-Create a new project
+Initialize a new project
 
 positional arguments:
   dependencies          Packages to add to the environment.yml in MatchSpec format.
@@ -51,7 +51,7 @@ optional arguments:
                         Comma separated list of conda configuration parameters to write into the .condarc file in the project directory. The
                         format for each config is key=value. For example --conda-configs experimental_solver=libmamba,channel_priority=strict
   --no-lock             Do no create the conda-lock.<env>.yml file(s)
-  --prepare             Create the local conda environment for the current platform.
+  --install             Create the local conda environment for the current platform.
 ```
 
 ### If I already have an `environment.yml`
@@ -89,7 +89,7 @@ commands: {}
 ```{note}
 Environment YAML files are specified as relative to the location of the `conda-project.yml` file.
 Each key in `environments:` can be utilized in `conda project lock <env-name>` or
- `conda project prepare <env-name>`.
+ `conda project install <env-name>`.
  These commands also accept `--all` to lock and prepare each of the defined environments.
 ```
 
@@ -116,8 +116,8 @@ To force a re-lock use `conda project lock --force`.
 
 ## Preparing your environments
 
-`conda project prepare` enforces the use of `conda-lock`.
-If a `conda-lock.<env>.yml` file is not present it will be created by prepare with the above
+`conda project install` enforces the use of `conda-lock`.
+If a `conda-lock.<env>.yml` file is not present it will be created by install with the above
 assumptions  if necessary.
 If a `conda-lock.<env>.yml` file is found but the locked platforms do not match your current platform
 it will raise an exception.
@@ -129,14 +129,14 @@ platform, similar to how `conda lock install` works.
 
 `conda project activate [environment]` will launch a shell and activate the named conda environment.
 If no environment name is supplied the first environment is activated. The `activate` command will
-force updating the lock and prepare the environment if it has not already been completed. Unlike
+force updating the lock and install the environment if it has not already been completed. Unlike
 `conda activate`, which is capable of adjusting your current shell process, `conda project activate`
 starts a new shell so it preferable to exit the shell back to the parent rather than running `conda deactivate`.
 
 ## Minimal example
 
 ```text
-❯ conda project create python=3.8
+❯ conda project init python=3.8
 Locking dependencies for default: done
 Locked dependencies for win-64, osx-64, osx-arm64, linux-64 platforms
 Project created at /Users/adefusco/Development/conda-incubator/conda-project/examples/new-project
@@ -357,7 +357,7 @@ The default value is the current working directory, `.` Every CondaProject has a
 conda environment.
 
 A project directory containing only an `environment.yml` file will create a single environment
-of the name `default`, which can be locked or prepared.
+of the name `default`, which can be locked or installed.
 If multiple environments are defined in a `conda-project.yml` the `.environments` attribute
 provides dictionary-style syntax for each named environment.
 The first defined conda environment in the `conda-project.yml` is accessible as

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -384,8 +384,8 @@ See the docstring for `.create()` for more details.
 ```python
 from conda_project import CondaProject
 
-project = CondaProject.create(
-  directory='new-project',
-  dependencies=['python=3.8'],
+project = CondaProject.init(
+   directory='new-project',
+   dependencies=['python=3.8'],
 )
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,8 +120,8 @@ def test_cli_directory_argument(action, mocker, capsys):
 def test_environment_actions_verbose_true(action, mocker, project_directory_factory):
     if action == "init":
         method_to_patch = "create"
-    elif action == "install":
-        method_to_patch = "prepare"
+    elif action == "prepare":
+        method_to_patch = "install"
     else:
         method_to_patch = action
     mocked_action = mocker.patch(f"conda_project.project.Environment.{method_to_patch}")
@@ -143,8 +143,8 @@ def test_environment_actions_verbose_true(action, mocker, project_directory_fact
 def test_project_actions_verbose_true(action, mocker, project_directory_factory):
     if action == "create":
         method_to_patch = "init"
-    elif action == "install":
-        method_to_patch = "prepare"
+    elif action == "prepare":
+        method_to_patch = "install"
     else:
         method_to_patch = action
 
@@ -170,7 +170,7 @@ def test_init_with_install(mocker):
     ret = parse_and_run(["init", "--directory", "project-dir", "--install"])
     assert ret == 0
 
-    assert default_environment.prepare.call_count == 1
+    assert default_environment.install.call_count == 1
 
 
 @pytest.mark.parametrize("action", ENVIRONMENT_ACTIONS)
@@ -181,8 +181,8 @@ def test_action_with_environment_name(action, multi_env, mocker):
     ret = parse_and_run([action, "--directory", str(multi_env), "env1"])
     assert ret == 0
 
-    if action == "install":
-        method_to_spy = "prepare"
+    if action == "prepare":
+        method_to_spy = "install"
     else:
         method_to_spy = action
 
@@ -192,7 +192,7 @@ def test_action_with_environment_name(action, multi_env, mocker):
     assert getattr(environments["env1"], method_to_spy).call_count == 1
 
 
-@pytest.mark.parametrize("action", ["prepare", "clean"])
+@pytest.mark.parametrize("action", ["install", "clean"])
 def test_action_all_environments(action, mocker, multi_env):
     mocked_action = mocker.patch(f"conda_project.project.Environment.{action}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,7 +82,7 @@ def test_no_action(capsys, monkeypatch):
 def test_no_env_yaml(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
 
-    monkeypatch.setattr("sys.argv", ["conda-project", "prepare"])
+    monkeypatch.setattr("sys.argv", ["conda-project", "install"])
     assert main() == 1
 
     err = capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 from conda_project.cli.main import cli, main, parse_and_run
 from conda_project.project import CondaProject
 
-PROJECT_ACTIONS = ("create", "check")
+PROJECT_ACTIONS = ("init", "create", "check")
 ENVIRONMENT_ACTIONS = ("clean", "prepare", "lock", "activate")
 COMMAND_ACTIONS = ("run",)
 ALL_ACTIONS = PROJECT_ACTIONS + ENVIRONMENT_ACTIONS + COMMAND_ACTIONS
@@ -135,8 +135,15 @@ def test_environment_actions_verbose_true(action, mocker, project_directory_fact
 
 @pytest.mark.parametrize("action", PROJECT_ACTIONS)
 def test_project_actions_verbose_true(action, mocker, project_directory_factory):
-    mocked_action = mocker.patch(f"conda_project.project.CondaProject.{action}")
-    if action == "create":
+    if action == "init":
+        method_to_patch = "create"
+    else:
+        method_to_patch = action
+
+    mocked_action = mocker.patch(
+        f"conda_project.project.CondaProject.{method_to_patch}"
+    )
+    if action in {"init", "create"}:
         project_path = project_directory_factory()
     else:
         env_yaml = "dependencies: []\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,10 +164,10 @@ def test_project_actions_verbose_true(action, mocker, project_directory_factory)
     assert mocked_action.call_args.kwargs["verbose"]
 
 
-def test_create_with_prepare(mocker):
+def test_init_with_install(mocker):
     default_environment = mocker.spy(CondaProject, "default_environment")
 
-    ret = parse_and_run(["create", "--directory", "project-dir", "--prepare"])
+    ret = parse_and_run(["init", "--directory", "project-dir", "--install"])
     assert ret == 0
 
     assert default_environment.prepare.call_count == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,8 +141,8 @@ def test_environment_actions_verbose_true(action, mocker, project_directory_fact
 
 @pytest.mark.parametrize("action", PROJECT_ACTIONS)
 def test_project_actions_verbose_true(action, mocker, project_directory_factory):
-    if action == "init":
-        method_to_patch = "create"
+    if action == "create":
+        method_to_patch = "init"
     elif action == "install":
         method_to_patch = "prepare"
     else:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -186,12 +186,12 @@ def test_run_default_command_after_lock_and_install(
 
     project = one_env_one_command
     assert not project.default_environment.is_locked
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     project.default_command.run()
 
     assert project.default_environment.is_locked
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
     assert mocked_execvped.call_count == 1
     assert conda_run.call_args == mocker.call(
@@ -371,11 +371,11 @@ def test_activate_prepares_env(one_env_no_commands: CondaProject, mocker):
 
     project = one_env_no_commands
 
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     project.default_environment.activate()
 
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
 
 def test_activate_with_env_vars(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -177,7 +177,7 @@ def test_raise_command_not_found(one_env_no_commands: CondaProject):
         project.commands["the-command"].run()
 
 
-def test_run_default_command_after_lock_and_prepare(
+def test_run_default_command_after_lock_and_install(
     one_env_one_command: CondaProject, mocked_execvped, mocker
 ):
     from conda_project import project as project_module

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -200,7 +200,7 @@ def test_prepare_no_dependencies(project_directory_factory):
 
     conda_history = env_dir / "conda-meta" / "history"
     assert conda_history.exists()
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
 
 @pytest.mark.slow
@@ -215,7 +215,7 @@ def test_is_prepared(project_directory_factory):
     project = CondaProject(project_path)
 
     _ = project.default_environment.install()
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
     updated_yaml = dedent(
         """\
@@ -230,14 +230,14 @@ def test_is_prepared(project_directory_factory):
         f.write(updated_yaml)
 
     assert not project.default_environment.is_locked
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     _ = project.default_environment.install(force=False)
     assert project.default_environment.is_locked
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     _ = project.default_environment.install(force=True)
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
 
 @pytest.mark.slow
@@ -259,7 +259,7 @@ def test_is_prepared_with_pip_package(project_directory_factory):
     _ = project.default_environment.install()
 
     # This assertion won't pass if there are pip packages
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
     args = [
         "run",
@@ -284,17 +284,17 @@ def test_is_prepared_live_env_changed(project_directory_factory, capsys):
 
     _ = project.default_environment.install()
     assert project.default_environment.is_locked
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
     _ = call_conda(
         ["install", "-p", str(project.default_environment.prefix), "requests", "-y"]
     )
 
     assert project.default_environment.is_locked
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     _ = project.default_environment.install(force=False, verbose=True)
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     stdout = capsys.readouterr().out
     assert "The environment exists but does not match the locked dependencies" in stdout
@@ -313,17 +313,17 @@ def test_is_prepared_source_changed(project_directory_factory, capsys):
 
     _ = project.default_environment.install()
     assert project.default_environment.is_locked
-    assert project.default_environment.is_prepared
+    assert project.default_environment.is_consistent
 
     _ = call_conda(
         ["install", "-p", str(project.default_environment.prefix), "requests", "-y"]
     )
 
     assert project.default_environment.is_locked
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     _ = project.default_environment.install(force=False, verbose=True)
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
     stdout = capsys.readouterr().out
     assert "The environment exists but does not match the locked dependencies" in stdout
@@ -380,7 +380,7 @@ def test_install_and_clean(project_directory_factory):
 
     project.default_environment.clean()
     assert not conda_history.exists()
-    assert not project.default_environment.is_prepared
+    assert not project.default_environment.is_consistent
 
 
 @pytest.mark.slow

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -28,7 +28,7 @@ def test_project_create_new_directory(tmp_path, capsys):
     project_directory = tmp_path / "new-project"
     assert not os.path.exists(project_directory)
 
-    p = CondaProject.create(project_directory, lock_dependencies=False, verbose=True)
+    p = CondaProject.init(project_directory, lock_dependencies=False, verbose=True)
 
     assert os.path.exists(project_directory)
     assert p.project_yaml_path.exists()
@@ -45,15 +45,15 @@ def test_project_create_new_directory(tmp_path, capsys):
 
 
 def test_project_create_twice(tmp_path, capsys):
-    _ = CondaProject.create(tmp_path, lock_dependencies=False)
-    p = CondaProject.create(tmp_path, lock_dependencies=False, verbose=True)
+    _ = CondaProject.init(tmp_path, lock_dependencies=False)
+    p = CondaProject.init(tmp_path, lock_dependencies=False, verbose=True)
 
     out, _ = capsys.readouterr()
     assert f"Existing project file found at {p.project_yaml_path}.\n" == out
 
 
 def test_project_create_default_platforms(tmp_path):
-    p = CondaProject.create(tmp_path, lock_dependencies=False)
+    p = CondaProject.init(tmp_path, lock_dependencies=False)
 
     with p.default_environment.sources[0].open() as f:
         env = YAML().load(f)
@@ -62,7 +62,7 @@ def test_project_create_default_platforms(tmp_path):
 
 
 def test_project_create_specific_platforms(tmp_path):
-    p = CondaProject.create(tmp_path, platforms=["linux-64"], lock_dependencies=False)
+    p = CondaProject.init(tmp_path, platforms=["linux-64"], lock_dependencies=False)
 
     with p.default_environment.sources[0].open() as f:
         env = YAML().load(f)
@@ -71,7 +71,7 @@ def test_project_create_specific_platforms(tmp_path):
 
 
 def test_project_create_specific_channels(tmp_path):
-    p = CondaProject.create(
+    p = CondaProject.init(
         tmp_path,
         dependencies=["python=3.8", "numpy"],
         channels=["conda-forge", "defaults"],
@@ -86,7 +86,7 @@ def test_project_create_specific_channels(tmp_path):
 
 
 def test_project_create_default_channel(tmp_path):
-    p = CondaProject.create(
+    p = CondaProject.init(
         tmp_path, dependencies=["python=3.8", "numpy"], lock_dependencies=False
     )
 
@@ -98,7 +98,7 @@ def test_project_create_default_channel(tmp_path):
 
 
 def test_project_create_conda_configs(tmp_path):
-    p = CondaProject.create(
+    p = CondaProject.init(
         tmp_path,
         dependencies=["python=3.8", "numpy"],
         conda_configs=["experimental_solver=libmamba"],
@@ -113,9 +113,7 @@ def test_project_create_conda_configs(tmp_path):
 
 @pytest.mark.slow
 def test_project_create_and_lock(tmp_path):
-    p = CondaProject.create(
-        tmp_path, dependencies=["python=3.8"], lock_dependencies=True
-    )
+    p = CondaProject.init(tmp_path, dependencies=["python=3.8"], lock_dependencies=True)
     assert p.default_environment.lockfile.exists()
     assert p.default_environment.lockfile == tmp_path / "conda-lock.default.yml"
 


### PR DESCRIPTION
This PR addresses #43 and #71.

We rename the following subcommands:
* `create` -> `init`
* `prepare` -> `install`

I have maintained the internal method names for both.

Additionally, I have declared an alias subcommand for each, which can be used instead but which will log a warning to the user if used. Eventually, we may want to deprecate these in favor of the new names.