### PR TITLE
fix: docs pipeline

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ SOURCEDIR     = source
 BUILDDIR      = _build
 APIDOCSDIR    = $(SOURCEDIR)/api
 
-SRC = ../conda_project
+SRC = ../src/conda_project
 
 # Internal variables.
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) $(SOURCEDIR)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,4 +64,4 @@ html_theme_options = {
         },
     ],
 }
-html_static_path = ["_static"]
+html_static_path = []


### PR DESCRIPTION
Fixes the reference to the source directory during documentation build. Also removes the static directory setting, since the `_static` directory doesn't exist and sphinx was raising a warning.