### PR TITLE
Fix is_consistent again

### DIFF
--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -501,17 +501,23 @@ class Environment(BaseModel):
         # We only include locked packages for the current platform, and don't
         # include optional dependencies (e.g. compile/build)
         lock = parse_conda_lock_file(self.lockfile)
+        current_platform_packages = [
+            p
+            for p in lock.package
+            if p.platform == current_platform() and p.category == "main"
+        ]
 
         # When an environment is installed pypi packages take precedence
         deduped_lock = dedupe_list_of_dicts(
-            lock.package, key=lambda x: x.name, keep=lambda x: x.manager == "pip"
+            current_platform_packages,
+            key=lambda x: x.name,
+            keep=lambda x: x.manager == "pip",
         )
 
         locked_pkgs = set()
         for p in deduped_lock:
-            if p.platform == current_platform() and p.category == "main":
-                hash = p.hash.md5 if p.manager == "conda" else p.hash.sha256
-                locked_pkgs.add((p.name, p.version, p.manager, hash))
+            hash = p.hash.md5 if p.manager == "conda" else p.hash.sha256
+            locked_pkgs.add((p.name, p.version, p.manager, hash))
 
         # Compare the sets
         # We can do this because the tuples are hashable. Also we don't need to

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -48,10 +48,9 @@ def test_install_no_dependencies(project_directory_factory):
 @pytest.mark.slow
 def test_is_installed(project_directory_factory):
     env_yaml = dedent(
-        f"""\
+        """\
         name: test
         dependencies: [python=3.8]
-        platforms: [{current_platform()}]
         """
     )
     project_path = project_directory_factory(env_yaml=env_yaml)
@@ -61,12 +60,11 @@ def test_is_installed(project_directory_factory):
     assert project.default_environment.is_consistent
 
     updated_yaml = dedent(
-        f"""\
+        """\
         name: test
         dependencies:
           - python=3.8
           - requests
-        platforms: [{current_platform()}]
         """
     )
 


### PR DESCRIPTION
A bug was discovered in the revised is_consistent since the tests had only checked on one platform. The deduplication (necessary when the same package exists in conda and pip lock specs) was being performed globally on the lockfile and would return an incorrect unique collection for the current platform. Moving the filter before deduplication fixes the issue. test_is_installed has been revised to lock for default_platforms rather than the current_platform.