### PR TITLE
Make it possible to override project environments location

### DIFF
--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -1,0 +1,42 @@
+# Configuration
+
+## Environment Variables
+
+You can modify Conda Project configuration settings using these environment variables.
+
+### CONDA_PROJECT_ENVS_PATH
+
+This variable provides a list of directories to search for environments
+to use in projects, and where to build them when needed. The format
+is identical to a standard `PATH` variable on the host
+operating system---a list of directories separated by `:` on Unix systems
+and `;` on Windows---except that empty entries are permitted. The paths
+are interpreted as follows:
+
+- If a path is empty, it is interpreted as the default value `envs`.
+- If a path is relative, it is interpreted relative to the root directory
+  of the project itself (`PROJECT_DIR`). For example, a path entry
+  `envs` is interpreted as
+
+  - `$PROJECT_DIR/envs` (Unix)
+  - `%PROJECT_DIR%\envs` (Windows)
+
+- When searching for an environment, the directories are searched in
+  left-to-right order.
+- If an environment with the requested name is found nowhere in the path,
+  one will be created as a subdirectory of the first entry in the path.
+
+For example, given a Unix machine with
+
+`CONDA_PROJECT_ENVS_PATH=/opt/envs::envs2:/home/user/conda/envs`
+
+Then Anaconda Project will look for an environment named `default`
+in the following locations:
+
+- `/opt/envs/default`
+- `$PROJECT_DIR/envs/default`
+- `$PROJECT_DIR/envs2/default`
+- `/home/user/conda/envs/default`
+
+If no such environment exists, one will be created as `/opt/envs/default`,
+instead of the default location of `$PROJECT_DIR/envs/default`.

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -23,7 +23,7 @@ that empty entries are permitted. The paths are interpreted as follows:
   left-to-right order.
 - The first writeable directory will be used to create the environment
 
-The default behavior of Cond Project is 
+The default behavior of Cond Project is
 
 `CONDA_PROJECT_ENVS_PATH=envs`
 

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -6,14 +6,12 @@ You can modify Conda Project configuration settings using these environment vari
 
 ### CONDA_PROJECT_ENVS_PATH
 
-This variable provides a list of directories to search for environments
-to use in projects, and where to build them when needed. The format
-is identical to a standard `PATH` variable on the host
-operating system---a list of directories separated by `:` on Unix systems
-and `;` on Windows---except that empty entries are permitted. The paths
-are interpreted as follows:
+This variable provides a list of directories to the path where conda environments
+will be created for this project. The format is identical to a standard `PATH` variable on the host
+operating system---a list of directories separated by `:` on Unix systems and `;` on Windows---except
+that empty entries are permitted. The paths are interpreted as follows:
 
-- If a path is empty, it is interpreted as the default value `envs`.
+- If the path is aboslute, it used as-is
 - If a path is relative, it is interpreted relative to the root directory
   of the project itself (`PROJECT_DIR`). For example, a path entry
   `envs` is interpreted as
@@ -21,22 +19,21 @@ are interpreted as follows:
   - `$PROJECT_DIR/envs` (Unix)
   - `%PROJECT_DIR%\envs` (Windows)
 
-- When searching for an environment, the directories are searched in
+- When searching for a path to created an environment for the project, the directories are searched in
   left-to-right order.
-- If an environment with the requested name is found nowhere in the path,
-  one will be created as a subdirectory of the first entry in the path.
+- The first writeable directory will be used to create the environment
+
+The default behavior of Cond Project is 
+
+`CONDA_PROJECT_ENVS_PATH=envs`
 
 For example, given a Unix machine with
 
-`CONDA_PROJECT_ENVS_PATH=/opt/envs::envs2:/home/user/conda/envs`
+`CONDA_PROJECT_ENVS_PATH=/opt/envs:envs2:/home/user/conda/envs`
 
-Then Anaconda Project will look for an environment named `default`
-in the following locations:
+Then Conda Project will create an environment named `default`
+in the first writeable of the following locations:
 
 - `/opt/envs/default`
-- `$PROJECT_DIR/envs/default`
 - `$PROJECT_DIR/envs2/default`
 - `/home/user/conda/envs/default`
-
-If no such environment exists, one will be created as `/opt/envs/default`,
-instead of the default location of `$PROJECT_DIR/envs/default`.

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -8,10 +8,10 @@ You can modify Conda Project configuration settings using these environment vari
 
 This variable provides a list of directories to the path where conda environments
 will be created for this project. The format is identical to a standard `PATH` variable on the host
-operating system---a list of directories separated by `:` on Unix systems and `;` on Windows---except
-that empty entries are permitted. The paths are interpreted as follows:
+operating system, a list of directories separated by `:` on Unix systems and `;` on Windows,
+The paths are interpreted as follows:
 
-- If the path is aboslute, it used as-is
+- If the path is aboslute it used as-is
 - If a path is relative, it is interpreted relative to the root directory
   of the project itself (`PROJECT_DIR`). For example, a path entry
   `envs` is interpreted as
@@ -19,11 +19,11 @@ that empty entries are permitted. The paths are interpreted as follows:
   - `$PROJECT_DIR/envs` (Unix)
   - `%PROJECT_DIR%\envs` (Windows)
 
-- When searching for a path to created an environment for the project, the directories are searched in
+- When searching for a path to create an environment for the project, the directories are searched in
   left-to-right order.
 - The first writeable directory will be used to create the environment
 
-The default behavior of Cond Project is
+The default behavior of Conda Project is
 
 `CONDA_PROJECT_ENVS_PATH=envs`
 

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -307,13 +307,13 @@ class CondaProject:
 
     @property
     def environments(self) -> BaseEnvironments:
-        default_env_path = self.directory / "envs"
-        env_paths = os.environ.get("CONDA_PROJECT_ENVS_PATH", default_env_path).split(
-            os.pathsep
-        )
+        env_path = self.directory / "envs"
+        env_paths = os.environ.get("CONDA_PROJECT_ENVS_PATH", "").split(os.pathsep)
 
-        # TODO: determine that path is writeable
-        env_path = Path(env_paths[0])
+        for path in env_paths:
+            if os.access(path, os.W_OK):
+                env_path = Path(path)
+                break
 
         envs = OrderedDict()
         for env_name, sources in self._project_file.environments.items():

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -307,12 +307,20 @@ class CondaProject:
 
     @property
     def environments(self) -> BaseEnvironments:
+        default_env_path = self.directory / "envs"
+        env_paths = os.environ.get("CONDA_PROJECT_ENVS_PATH", default_env_path).split(
+            os.pathsep
+        )
+
+        # TODO: determine that path is writeable
+        env_path = Path(env_paths[0])
+
         envs = OrderedDict()
         for env_name, sources in self._project_file.environments.items():
             envs[env_name] = Environment(
                 name=env_name,
                 sources=tuple([self.directory / str(s) for s in sources]),
-                prefix=self.directory / "envs" / env_name,
+                prefix=env_path / env_name,
                 lockfile=self.directory / f"conda-lock.{env_name}.yml",
                 project=weakref.proxy(self),
             )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 import os
+import platform
 from textwrap import dedent
 
 import pytest
@@ -510,6 +511,10 @@ def test_project_environment_env_path_specified(
     assert project.environments["my-env"].prefix == test_envs_path / "my-env"
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Windows has a hard time with read-only directories",
+)
 def test_project_environment_env_path_uses_first_writable(
     tmp_path, project_directory_factory, monkeypatch
 ):
@@ -542,6 +547,10 @@ def test_project_environment_env_path_uses_first_writable(
     )
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Windows has a hard time with read-only directories",
+)
 def test_project_environment_env_path_none_writable_uses_default(
     tmp_path, project_directory_factory, monkeypatch
 ):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 import os
-from pathlib import Path
 from textwrap import dedent
 
 import pytest

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -535,7 +535,7 @@ def test_project_environment_env_path_uses_first_writable(
     )
     project = CondaProject(project_path)
 
-    # Since the specified path was not writeable, should fall back to default
+    # Since the first path was not writable, should use the second path
     assert project.environments["my-env"].prefix == project.directory / "bananas/my-env"
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -536,7 +536,10 @@ def test_project_environment_env_path_uses_first_writable(
     project = CondaProject(project_path)
 
     # Since the first path was not writable, should use the second path
-    assert project.environments["my-env"].prefix == project.directory / "bananas/my-env"
+    assert (
+        project.environments["my-env"].prefix
+        == project.directory / "bananas" / "my-env"
+    )
 
 
 def test_project_environment_env_path_none_writable_uses_default(
@@ -563,7 +566,9 @@ def test_project_environment_env_path_none_writable_uses_default(
     project = CondaProject(project_path)
 
     # Since the specified path was not writeable, should fall back to default
-    assert project.environments["my-env"].prefix == project.directory / "envs/my-env"
+    assert (
+        project.environments["my-env"].prefix == project.directory / "envs" / "my-env"
+    )
 
 
 def test_project_environments_immutable(project_directory_factory):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -519,7 +519,7 @@ def test_project_environment_env_path_uses_first_writable(
     test_envs_path2.mkdir(mode=0o777)
     monkeypatch.setenv(
         "CONDA_PROJECT_ENVS_PATH",
-        f"{str(test_envs_path1)}:{str(test_envs_path2)}",
+        f"{str(test_envs_path1)}{os.pathsep}{str(test_envs_path2)}",
     )
 
     env_yaml = f"dependencies: []\nplatforms: [{current_platform()}]"


### PR DESCRIPTION
https://github.com/conda-incubator/conda-project/issues/121 / TULZ-862

This PR makes it possible to set the location of project environments by setting the CONDA_PROJECT_ENVS_PATH environment variable. 

To test:
- `conda project init --directory test-project`
- `export CONDA_PROJECT_ENVS_PATH=<directory where environments should be created>`
- `cd test-project`
- `conda project activate`
- You should see the default environment created in the specified directory rather than `test-project/envs`