### PR TITLE
Handle relative paths and writing nonexistent directories for CONDA_PROJECT_ENVS_PATH

### DIFF
--- a/.github/disclaimer.txt
+++ b/.github/disclaimer.txt
@@ -1,2 +1,2 @@
-Copyright (C) 2022 Anaconda, Inc
+Copyright (C) 2024 Anaconda, Inc
 SPDX-License-Identifier: BSD-3-Clause

--- a/.github/disclaimer.txt
+++ b/.github/disclaimer.txt
@@ -1,2 +1,2 @@
-Copyright (C) 2024 Anaconda, Inc
+Copyright (C) 2022-2024 Anaconda, Inc
 SPDX-License-Identifier: BSD-3-Clause

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/examples/multi-env-files/print_version.py
+++ b/examples/multi-env-files/print_version.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/examples/multi-env-files/test_get_version.py
+++ b/examples/multi-env-files/test_get_version.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/scripts/ap-to-cp.py
+++ b/scripts/ap-to-cp.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/conda_project/__init__.py
+++ b/src/conda_project/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/conda_project/__main__.py
+++ b/src/conda_project/__main__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from .cli.main import main

--- a/src/conda_project/cli/__init__.py
+++ b/src/conda_project/cli/__init__.py
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause

--- a/src/conda_project/cli/commands.py
+++ b/src/conda_project/cli/commands.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import logging

--- a/src/conda_project/cli/main.py
+++ b/src/conda_project/cli/main.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations

--- a/src/conda_project/conda.py
+++ b/src/conda_project/conda.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations

--- a/src/conda_project/exceptions.py
+++ b/src/conda_project/exceptions.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -34,12 +34,12 @@ from conda_lock.conda_lock import (
 )
 from fsspec.core import split_protocol
 
-try:
+try:  # pragma: no-cover
     # Version 2 provides a v1 API
-    from pydantic.v1 import BaseModel, create_model
-except ImportError:
-    from pydantic import BaseModel  # type: ignore
-    from pydantic import create_model  # type: ignore
+    from pydantic.v1 import BaseModel, create_model  # pragma: no cover
+except ImportError:  # pragma: no cover
+    from pydantic import BaseModel  # type: ignore; #pragma: no cover
+    from pydantic import create_model  # type: ignore; #pragma no cover
 
 from .conda import (
     CONDA_EXE,

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -312,8 +312,16 @@ class CondaProject:
         env_paths = specified_path.split(os.pathsep) if specified_path else []
 
         for path in env_paths:
-            if path and (os.access(path, os.W_OK) or not os.path.exists(path)):
-                env_path = Path(os.path.join(self.directory, path))
+            if not path:
+                continue
+
+            # Construct absolute path
+            path = self.directory / path
+
+            path_writable = path.exists() and os.access(path, os.W_OK)
+            parent_writable = (not path.exists()) and os.access(path.parent, os.W_OK)
+            if path_writable or parent_writable:
+                env_path = path
                 break
 
         envs = OrderedDict()

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -311,8 +311,8 @@ class CondaProject:
         env_paths = os.environ.get("CONDA_PROJECT_ENVS_PATH", "").split(os.pathsep)
 
         for path in env_paths:
-            if os.access(path, os.W_OK):
-                env_path = Path(path)
+            if os.access(path, os.W_OK) or not os.path.exists(path):
+                env_path = Path(os.path.join(self.directory, path))
                 break
 
         envs = OrderedDict()

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -805,10 +805,8 @@ class Environment(BaseModel):
         verbose: bool = False,
     ) -> None:
         """Remove the conda environment."""
-
-        breakpoint()
         _ = call_conda(
-            ["env", "remove", "-p", str(self.prefix)],
+            ["env", "remove", "-y", "-p", str(self.prefix)],
             condarc_path=self.project.condarc,
             verbose=verbose,
             logger=logger,

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -308,10 +308,11 @@ class CondaProject:
     @property
     def environments(self) -> BaseEnvironments:
         env_path = self.directory / "envs"
-        env_paths = os.environ.get("CONDA_PROJECT_ENVS_PATH", "").split(os.pathsep)
+        specified_path = os.environ.get("CONDA_PROJECT_ENVS_PATH", "")
+        env_paths = specified_path.split(os.pathsep) if specified_path else []
 
         for path in env_paths:
-            if os.access(path, os.W_OK) or not os.path.exists(path):
+            if path and (os.access(path, os.W_OK) or not os.path.exists(path)):
                 env_path = Path(os.path.join(self.directory, path))
                 break
 
@@ -805,6 +806,7 @@ class Environment(BaseModel):
     ) -> None:
         """Remove the conda environment."""
 
+        breakpoint()
         _ = call_conda(
             ["env", "remove", "-p", str(self.prefix)],
             condarc_path=self.project.condarc,

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2024 Anaconda, Inc
-# SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2022-2024 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -312,9 +312,6 @@ class CondaProject:
         env_paths = specified_path.split(os.pathsep) if specified_path else []
 
         for path in env_paths:
-            if not path:
-                continue
-
             # Construct absolute path
             path = self.directory / path
 

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
@@ -311,9 +314,11 @@ class CondaProject:
         specified_path = os.environ.get("CONDA_PROJECT_ENVS_PATH", "")
         env_paths = specified_path.split(os.pathsep) if specified_path else []
 
-        for path in env_paths:
-            # Construct absolute path
-            path = self.directory / path
+        for _path in env_paths:
+            path = Path(_path)
+
+            if not path.is_absolute():
+                path = self.directory / path
 
             path_writable = path.exists() and os.access(path, os.W_OK)
             parent_writable = (not path.exists()) and os.access(path.parent, os.W_OK)

--- a/src/conda_project/project_file.py
+++ b/src/conda_project/project_file.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2024 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
@@ -11,13 +11,13 @@ from conda_lock._vendor.conda.models.match_spec import MatchSpec
 from pkg_resources import Requirement
 from ruamel.yaml import YAML
 
-try:
+try:  # pragma: no cover
     # Version 2 provides a v1 API
-    from pydantic.v1 import BaseModel, ValidationError, validator
-except ImportError:
-    from pydantic import BaseModel  # type: ignore
-    from pydantic import ValidationError  # type: ignore
-    from pydantic import validator  # type: ignore
+    from pydantic.v1 import BaseModel, ValidationError, validator  # pragma: no cover
+except ImportError:  # pragma: no cover
+    from pydantic import BaseModel  # type: ignore; #pragma: no cover
+    from pydantic import ValidationError  # type: ignore; #pragma: no cover
+    from pydantic import validator  # type: ignore; #pragma: no cover
 
 from .exceptions import CondaProjectError
 

--- a/src/conda_project/project_file.py
+++ b/src/conda_project/project_file.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2024 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations

--- a/src/conda_project/utils.py
+++ b/src/conda_project/utils.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2024 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,31 @@
+# Copyright (C) 2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from tempfile import TemporaryDirectory
+from typing import Generator, Optional
 
 import pytest
 
 from conda_project.conda import call_conda
 from conda_project.project import CondaProject, current_platform
+
+
+@pytest.fixture
+def tmp_dir() -> Generator[Path, None, None]:
+    """create a temporary directory
+
+    This is useful if you want to two independent directories created for a test
+    since re-using `tmp_path` is not possible.
+    """
+
+    with TemporaryDirectory() as d:
+        yield Path(d)
 
 
 @pytest.fixture()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from argparse import Namespace

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import os

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import logging

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -605,6 +605,10 @@ def test_project_environment_envs_path_creates_first_possible_dir(
     )
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Windows has a hard time with read-only directories",
+)
 def test_project_environment_envs_path_project_dir_not_writable(
     tmp_path, project_directory_factory, monkeypatch
 ):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2024 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/test_project_file.py
+++ b/tests/test_project_file.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 


### PR DESCRIPTION
Update some behavior around the CONDA_PROJECT_ENVS_PATH variable so that relative paths are always interpreted relative to the project root and non-existent directories are created.