### PR TITLE
Expand vars in envs_path

### DIFF
--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -61,6 +61,7 @@ from .utils import (
     dedupe_list_of_dicts,
     env_variable,
     find_file,
+    get_envs_paths,
     prepare_variables,
 )
 
@@ -333,13 +334,9 @@ class CondaProject:
     @property
     def environments(self) -> BaseEnvironments:
         env_path = self.directory / "envs"
-        specified_path = os.environ.get("CONDA_PROJECT_ENVS_PATH", "")
-        env_paths = specified_path.split(os.pathsep) if specified_path else []
+        env_paths = get_envs_paths()
 
-        for _path in env_paths:
-            expanded = os.path.expandvars(_path)
-            path = Path(expanded)
-
+        for path in env_paths:
             if not path.is_absolute():
                 path = self.directory / path
 

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -337,7 +337,8 @@ class CondaProject:
         env_paths = specified_path.split(os.pathsep) if specified_path else []
 
         for _path in env_paths:
-            path = Path(_path)
+            expanded = os.path.expandvars(_path)
+            path = Path(expanded)
 
             if not path.is_absolute():
                 path = self.directory / path

--- a/src/conda_project/utils.py
+++ b/src/conda_project/utils.py
@@ -197,3 +197,10 @@ def dedupe_list_of_dicts(data: list, key: Callable, keep: Callable) -> list:
         else:
             deduped.extend(values)
     return deduped
+
+
+def get_envs_paths() -> List[Path]:
+    specified_path = os.environ.get("CONDA_PROJECT_ENVS_PATH", "")
+    env_paths = specified_path.split(os.pathsep) if specified_path else []
+    expanded_paths = [Path(os.path.expandvars(path)) for path in env_paths]
+    return expanded_paths

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,7 @@ from conda_project.utils import (
     env_variable,
     execvped,
     find_file,
+    get_envs_paths,
     is_windows,
     prepare_variables,
 )
@@ -299,3 +300,11 @@ def test_dedupe_list_of_dicts():
         {"name": "ccc", "k1": "cat1"},
         {"name": "ddd", "k1": "cat2"},
     ]
+
+
+def test_get_envs_path_expanded(monkeypatch):
+    monkeypatch.setenv("FAKE_HOME", "/path/to/home")
+    var = r"%FAKE_HOME%" if is_windows() else "$FAKE_HOME"
+    monkeypatch.setenv("CONDA_PROJECT_ENVS_PATH", f"{var}/.conda/envs{os.pathsep}envs")
+
+    assert get_envs_paths() == [Path("/path/to/home/.conda/envs"), Path("envs")]


### PR DESCRIPTION
This allows something like `CONDA_PROJECT_ENVS_PATH=$HOME/.conda/envs:envs` and `CONDA_PROJECT=%HOME%/.conda/envs:envs` on windows