### PR TITLE
[chore] sorting lockfile keys and suppressing progress output

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     {% endfor %}
   run:
     - python {{ project['requires-python'] }}
-    - conda-lock >=2.2
+    - conda-lock >=2.5.6
     - lockfile
     - pexpect
     - ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
-  - flake8
-  - mypy
-  - pytest
-  - pylint
-  - pytest-cov
-  - pytest-mock
+  - python=3.10
   - pre-commit
-  - conda-lock>=2.2
-  - pydantic
-  - ruamel.yaml
-  - setuptools-scm>=6.2
-  - shellingham
-  - python-dotenv
-  - lockfile
-  - pexpect
-  - fsspec
-  - python-libarchive-c
   - pip
   - pip:
-    - -e .
+    - "-e .[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,18 @@ version_scheme = "post-release"
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/src/conda_project",
-  "/pyproject.toml"
+    "/src/conda_project",
+    "/pyproject.toml"
 ]
 
 [project.optional-dependencies]
+dev = [
+    "black",
+    "mypy",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+]
 docs = [
     "sphinx>=5.1.1",
     "sphinx-autobuild>=2021.3.14",

--- a/src/conda_project/cli/commands.py
+++ b/src/conda_project/cli/commands.py
@@ -60,6 +60,7 @@ def handle_errors(func: Callable[[Namespace], Any]) -> Callable[[Namespace], int
 
 @handle_errors
 def init(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = CondaProject.init(
         directory=args.directory,
         name=args.name,
@@ -71,11 +72,11 @@ def init(args: Namespace) -> bool:
         ),
         lock_dependencies=args.lock,
         from_environment=args.from_environment,
-        verbose=True,
+        verbose=verbose,
     )
 
     if args.install:
-        project.default_environment.install(verbose=True)
+        project.default_environment.install(verbose=verbose)
 
     return True
 
@@ -89,6 +90,7 @@ def create(args: Namespace) -> int:
 
 @handle_errors
 def lock(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = _load_project(args)
 
     if args.environment:
@@ -97,31 +99,33 @@ def lock(args: Namespace) -> bool:
         to_lock = project.environments.values()
 
     for env in to_lock:
-        env.lock(force=args.force, verbose=True)
+        env.lock(force=args.force, verbose=verbose)
 
     return True
 
 
 @handle_errors
 def check(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = _load_project(args)
-    return project.check(verbose=True)
+    return project.check(verbose=verbose)
 
 
 @handle_errors
 def install(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = _load_project(args)
 
     if args.all:
         for _, env in project.environments:
-            env.install(force=args.force, verbose=True)
+            env.install(force=args.force, verbose=verbose)
     else:
         env = (
             project.environments[args.environment]
             if args.environment
             else project.default_environment
         )
-        env.install(force=args.force, as_platform=args.as_platform, verbose=True)
+        env.install(force=args.force, as_platform=args.as_platform, verbose=verbose)
 
     return True
 
@@ -135,6 +139,7 @@ def prepare(args: Namespace) -> int:
 
 @handle_errors
 def add(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = _load_project(args)
 
     env = (
@@ -143,12 +148,13 @@ def add(args: Namespace) -> bool:
         else project.default_environment
     )
 
-    env.add(args.dependencies, args.channel, verbose=True)
+    env.add(args.dependencies, args.channel, verbose=verbose)
     return True
 
 
 @handle_errors
 def remove(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = _load_project(args)
 
     env = (
@@ -157,30 +163,32 @@ def remove(args: Namespace) -> bool:
         else project.default_environment
     )
 
-    env.remove(args.dependencies, verbose=True)
+    env.remove(args.dependencies, verbose=verbose)
     return True
 
 
 @handle_errors
 def clean(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = CondaProject(args.directory)
 
     if args.all:
         for env in project.environments.values():
-            env.clean(verbose=True)
+            env.clean(verbose=verbose)
     else:
         env = (
             project.environments[args.environment]
             if args.environment
             else project.default_environment
         )
-        env.clean(verbose=True)
+        env.clean(verbose=verbose)
 
     return True
 
 
 @handle_errors
 def run(args: Namespace) -> NoReturn:
+    verbose = not args.quiet
     project = _load_project(args)
 
     if args.command:
@@ -200,12 +208,13 @@ def run(args: Namespace) -> NoReturn:
         environment=args.environment,
         external_environment=args.external_environment,
         extra_args=args.extra_args,
-        verbose=True,
+        verbose=verbose,
     )
 
 
 @handle_errors
 def activate(args: Namespace) -> bool:
+    verbose = not args.quiet
     project = _load_project(args)
 
     if args.environment:
@@ -213,6 +222,6 @@ def activate(args: Namespace) -> bool:
     else:
         env = project.default_environment
 
-    env.activate(verbose=True)
+    env.activate(verbose=verbose)
 
     return True

--- a/src/conda_project/cli/main.py
+++ b/src/conda_project/cli/main.py
@@ -50,6 +50,7 @@ def cli() -> ArgumentParser:
         action="store",
         default=None,
     )
+    extras.add_argument("--quiet", help="Suppress output", action="store_true")
 
     p = ArgumentParser(
         description="Tool for encapsulating, running, and reproducing projects with conda environments",

--- a/src/conda_project/cli/main.py
+++ b/src/conda_project/cli/main.py
@@ -50,7 +50,9 @@ def cli() -> ArgumentParser:
         action="store",
         default=None,
     )
-    extras.add_argument("--quiet", help="Suppress output", action="store_true")
+
+    quiet = ArgumentParser(add_help=False)
+    quiet.add_argument("--quiet", help="Suppress output", action="store_true")
 
     p = ArgumentParser(
         description="Tool for encapsulating, running, and reproducing projects with conda environments",
@@ -66,15 +68,15 @@ def cli() -> ArgumentParser:
 
     subparsers = p.add_subparsers(metavar="command", required=True)
 
-    _create_init_parser(subparsers, common)
-    _create_lock_parser(subparsers, common, extras)
-    _create_check_parser(subparsers, common, extras)
-    _create_install_parser(subparsers, common, extras)
-    _create_add_parser(subparsers, common, extras)
-    _create_remove_parser(subparsers, common, extras)
-    _create_activate_parser(subparsers, common, extras)
-    _create_clean_parser(subparsers, common)
-    _create_run_parser(subparsers, common, extras)
+    _create_init_parser(subparsers, common, quiet)
+    _create_lock_parser(subparsers, common, extras, quiet)
+    _create_check_parser(subparsers, common, extras, quiet)
+    _create_install_parser(subparsers, common, extras, quiet)
+    _create_add_parser(subparsers, common, extras, quiet)
+    _create_remove_parser(subparsers, common, extras, quiet)
+    _create_activate_parser(subparsers, common, extras, quiet)
+    _create_clean_parser(subparsers, common, quiet)
+    _create_run_parser(subparsers, common, extras, quiet)
 
     return p
 

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -62,6 +62,7 @@ from .utils import (
     env_variable,
     find_file,
     get_envs_paths,
+    order_dict_keys,
     prepare_variables,
 )
 
@@ -106,6 +107,20 @@ def _load_pip_sha256_hashes(prefix: str) -> dict[str, str]:
         if m is not None:
             pip_sha256[m.group("name").lower().replace("_", "-")] = m.group("sha256")
     return pip_sha256
+
+
+def _sort_lockfile_keys(lockfile: Path, metadata_choices: Optional[set] = None) -> None:
+    """Some nested keys in the lockfile have unspecified ordering"""
+    lock = parse_conda_lock_file(lockfile)
+
+    lock.metadata.content_hash = order_dict_keys(lock.metadata.content_hash)
+    lock.metadata.platforms = sorted(lock.metadata.platforms)
+
+    for pkg in lock.package:
+        pkg.hash
+        pkg.dependencies = order_dict_keys(pkg.dependencies)
+
+    write_conda_lock_file(lock, lockfile, metadata_choices=metadata_choices or {})
 
 
 class CondaProject:
@@ -673,6 +688,7 @@ class Environment(BaseModel):
                         msg = "Project failed to lock\n" + msg
                         raise CondaProjectLockFailed(msg)
 
+        _sort_lockfile_keys(self.lockfile, metadata_choices={MetadataOption.TimeStamp})
         lock = parse_conda_lock_file(self.lockfile)
         msg = f"Locked dependencies for {', '.join(lock.metadata.platforms)} platforms"
         logger.info(msg)

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -791,6 +791,8 @@ class Environment(BaseModel):
             ]
             if force:
                 args.append("--force")
+            if not sys.stdout.isatty():
+                args.append("--quiet")
 
             _ = call_conda(
                 args,

--- a/src/conda_project/utils.py
+++ b/src/conda_project/utils.py
@@ -10,7 +10,7 @@ import platform
 import sys
 import threading
 import time
-from collections import ChainMap
+from collections import ChainMap, OrderedDict
 from collections.abc import Generator
 from contextlib import contextmanager
 from inspect import Traceback
@@ -212,3 +212,10 @@ def get_envs_paths() -> List[Path]:
     env_paths = specified_path.split(os.pathsep) if specified_path else []
     expanded_paths = [Path(os.path.expandvars(path)) for path in env_paths]
     return expanded_paths
+
+
+def order_dict_keys(unordered: dict) -> OrderedDict:
+    ordered = OrderedDict(
+        sorted([(k, v) for k, v in unordered.items()], key=lambda d: d[0])
+    )
+    return ordered

--- a/src/conda_project/utils.py
+++ b/src/conda_project/utils.py
@@ -52,8 +52,6 @@ class Spinner:
 
     def __init__(self, prefix: str):
         self.prefix = prefix
-        self._event = threading.Event()
-        self._thread = threading.Thread(target=self._spin)
 
     def _spin(self) -> None:
         spinner = itertools.cycle(["◜", "◠", "◝", "◞", "◡", "◟"])
@@ -66,9 +64,19 @@ class Spinner:
             time.sleep(0.10)
 
     def start(self) -> None:
+        if not sys.stdout.isatty():
+            print(self.prefix)
+            return
+
+        self._event = threading.Event()
+        self._thread = threading.Thread(target=self._spin)
         self._thread.start()
 
     def stop(self) -> None:
+        if not sys.stdout.isatty():
+            print("Done")
+            return
+
         self._event.set()
         self._thread.join()
         sys.stdout.write("\r")


### PR DESCRIPTION
Some elements of the conda-lock lockfile are unordered dicts or lists. As a quick fix for cases where someone is working with diffs of lockfiles I've sorted the following keys when a lockfile is written
* metadata.content_hash
* metadata.platforms
* package.*.dependencies

Secondly, to support headless uses of conda-project a `--quiet` flag has been added to all commands and if conda-project detects that your shell is not connected to a TTY will suppress progress-style outputs when not using `--quiet`.