### PR TITLE
[chore] install for command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           make -C docs html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'docs/_build/html'
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -173,7 +173,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Download the build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: package-${{ github.sha }}
         path: conda-bld
@@ -202,7 +202,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
     - name: Download the build artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+      uses: actions/download-artifact@v4
       with:
         name: builds-${{ github.sha }}
         path: ~/dist

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,7 +39,7 @@ jobs:
           source $CONDA/bin/activate && conda activate build-conda-project
           VERSION=`hatch version` conda build -c conda-forge --output-folder conda-build conda.recipe
       - name: Upload the build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package-${{ github.sha }}
           path: conda-build
@@ -61,7 +61,7 @@ jobs:
       - name: Build the package
         run: python -m build
       - name: Upload the build artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@v4
         with:
           name: builds-${{ github.sha }}
           path: dist/*

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     {% endfor %}
   run:
     - python {{ project['requires-python'] }}
-    - conda-lock >=2.2
+    - conda-lock >=2.5.6,<3
     - lockfile
     - pexpect
     - ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
-  - flake8
-  - mypy
-  - pytest
-  - pylint
-  - pytest-cov
-  - pytest-mock
-  - pre-commit
-  - conda-lock>=2.2
-  - pydantic
-  - ruamel.yaml
-  - setuptools-scm>=6.2
-  - shellingham
-  - python-dotenv
-  - lockfile
-  - pexpect
-  - fsspec
-  - python-libarchive-c
-  - pip
+  - python=3.9
+  - conda-lock>=2.5.6,<3
   - pip:
-    - -e .
+    - -e ".[dev]"

--- a/etc/test-environment.yml
+++ b/etc/test-environment.yml
@@ -2,7 +2,7 @@ name: test-conda-project
 channels:
   - conda-forge
 dependencies:
-  - conda-lock>=2.2
+  - conda-lock>=2.5,8,<3
   - pexpect
   - lockfile
   - ruamel.yaml

--- a/etc/test-environment.yml
+++ b/etc/test-environment.yml
@@ -2,7 +2,7 @@ name: test-conda-project
 channels:
   - conda-forge
 dependencies:
-  - conda-lock>=2.5,8,<3
+  - conda-lock>=2.5.6,<3
   - pexpect
   - lockfile
   - ruamel.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "conda-lock >=2.5.6",
+    "conda-lock >=2.5.6,<3",
     "lockfile",
     "pexpect",
     "ruamel.yaml",
@@ -60,6 +60,14 @@ include = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "flake8",
+    "mypy",
+    "pytest",
+    "pylint",
+    "pytest-cov",
+    "pytest-mock"
+]
 docs = [
     "sphinx>=5.1.1",
     "sphinx-autobuild>=2021.3.14",

--- a/src/conda_project/cli/commands.py
+++ b/src/conda_project/cli/commands.py
@@ -109,6 +109,9 @@ def check(args: Namespace) -> bool:
 
 
 def _get_environment_from_args(project: CondaProject, args: Namespace) -> Environment:
+    if args.environment and args.for_command:
+        raise CondaProjectError("You must specify one of environment or --for-command")
+
     if args.for_command:
         env = project.commands[args.for_command].environment
         environment = env.name if env is not None else None
@@ -131,11 +134,6 @@ def install(args: Namespace) -> bool:
         for _, env in project.environments:
             env.install(force=args.force, verbose=True)
     else:
-        if args.environment and args.for_command:
-            raise CondaProjectError(
-                "You must specify one of environment or --for-command"
-            )
-
         env = _get_environment_from_args(project, args)
         env.install(force=args.force, as_platform=args.as_platform, verbose=True)
 

--- a/src/conda_project/cli/commands.py
+++ b/src/conda_project/cli/commands.py
@@ -116,9 +116,20 @@ def install(args: Namespace) -> bool:
         for _, env in project.environments:
             env.install(force=args.force, verbose=True)
     else:
+        if args.environment and args.for_command:
+            raise CondaProjectError(
+                "You must specify one of environment or --for-command"
+            )
+
+        if args.for_command:
+            env = project.commands[args.for_command].environment
+            environment = env.name if env is not None else None
+        else:
+            environment = args.environment
+
         env = (
-            project.environments[args.environment]
-            if args.environment
+            project.environments[environment]
+            if environment
             else project.default_environment
         )
         env.install(force=args.force, as_platform=args.as_platform, verbose=True)

--- a/src/conda_project/cli/commands.py
+++ b/src/conda_project/cli/commands.py
@@ -11,7 +11,7 @@ from functools import wraps
 from typing import Any, Callable, NoReturn
 
 from ..exceptions import CommandNotFoundError, CondaProjectError
-from ..project import Command, CondaProject
+from ..project import Command, CondaProject, Environment
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +108,21 @@ def check(args: Namespace) -> bool:
     return project.check(verbose=True)
 
 
+def _get_environment_from_args(project: CondaProject, args: Namespace) -> Environment:
+    if args.for_command:
+        env = project.commands[args.for_command].environment
+        environment = env.name if env is not None else None
+    else:
+        environment = args.environment
+
+    env = (
+        project.environments[environment]
+        if environment
+        else project.default_environment
+    )
+    return env
+
+
 @handle_errors
 def install(args: Namespace) -> bool:
     project = _load_project(args)
@@ -121,17 +136,7 @@ def install(args: Namespace) -> bool:
                 "You must specify one of environment or --for-command"
             )
 
-        if args.for_command:
-            env = project.commands[args.for_command].environment
-            environment = env.name if env is not None else None
-        else:
-            environment = args.environment
-
-        env = (
-            project.environments[environment]
-            if environment
-            else project.default_environment
-        )
+        env = _get_environment_from_args(project, args)
         env.install(force=args.force, as_platform=args.as_platform, verbose=True)
 
     return True

--- a/src/conda_project/cli/main.py
+++ b/src/conda_project/cli/main.py
@@ -237,6 +237,11 @@ def _create_install_parser(
             nargs="?",
         )
         group.add_argument(
+            "--for-command",
+            help="Prepare the environment configured for the desired command. Not "
+            "compatible with the environment argument.",
+        )
+        group.add_argument(
             "--as-platform",
             help="Prepare the conda environment assuming a different platform/subdir name.",
             action="store",

--- a/src/conda_project/project.py
+++ b/src/conda_project/project.py
@@ -836,6 +836,9 @@ class Environment(BaseModel):
         verbose: bool = False,
     ) -> None:
         """Remove the conda environment."""
+        if not self.prefix.exists():
+            return
+
         _ = call_conda(
             ["env", "remove", "-y", "-p", str(self.prefix)],
             condarc_path=self.project.condarc,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -451,7 +451,7 @@ def test_install_env_for_command(project_directory_factory, for_command, expecte
             f"env2{project_directory_factory._suffix}": env_yaml,
         },
     )
-    
+
     with pytest.raises(CondaProjectError):
         args = Namespace(
             directory=project_path,
@@ -463,7 +463,7 @@ def test_install_env_for_command(project_directory_factory, for_command, expecte
         project = _load_project(args)
 
         _ = _get_environment_from_args(project, args)
-    
+
     args = Namespace(
         directory=project_path,
         environment=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from pytest_mock import MockFixture
 
 from conda_project.cli.commands import _get_environment_from_args, _load_project
 from conda_project.cli.main import cli, main, parse_and_run
+from conda_project.exceptions import CondaProjectError
 from conda_project.project import CondaProject, current_platform
 
 PROJECT_ACTIONS = ("init", "create", "check")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -451,7 +451,19 @@ def test_install_env_for_command(project_directory_factory, for_command, expecte
             f"env2{project_directory_factory._suffix}": env_yaml,
         },
     )
+    
+    with pytest.raises(CondaProjectError):
+        args = Namespace(
+            directory=project_path,
+            environment="env",
+            project_archive=None,
+            archive_storage_options=None,
+            for_command="cmd",
+        )
+        project = _load_project(args)
 
+        _ = _get_environment_from_args(project, args)
+    
     args = Namespace(
         directory=project_path,
         environment=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,7 +454,7 @@ def test_install_env_for_command(project_directory_factory, for_command, expecte
 
     args = Namespace(
         directory=project_path,
-        environment=expected_env,
+        environment=None,
         project_archive=None,
         archive_storage_options=None,
         for_command=for_command,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -46,6 +46,8 @@ def test_install_and_clean(project_directory_factory):
     project_path = project_directory_factory(env_yaml=env_yaml)
 
     project = CondaProject(project_path)
+    project.default_environment.clean()
+
     env_dir = project.default_environment.install()
     assert env_dir.samefile(project_path / "envs" / "default")
 


### PR DESCRIPTION
install an env for a specified command (especially if it is not default)

```
> conda project install --for-command=<cmd-name>
```