### PR TITLE
[chore] support conda-lock 2 and 3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -143,7 +143,7 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ $RUNNER_OS == 'Windows' ]; then
-            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forgge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
+            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
           else
             source $HOME/miniconda/bin/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
           fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,31 +69,30 @@ jobs:
           retention-days: 7
 
   test:
-    name: Test (conda ${{ matrix.conda-version }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Test (conda ${{ matrix.conda-version }}, conda-lock ${{ matrix.conda-lock }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [3.9, "3.10", "3.11", "3.12"]
-        conda-version: ["4.14", "22.9", "22.11", "23.5", "23.9", "24.1" , "24.4"]
+        conda-version: ["23.5", "23.9", "24.1" , "24.4", "25.3"]
+        conda-lock: ["2.5.6", "3"]
         exclude:
-          # Python 3.11
-          - conda-version: "4.14"
-            python-version: "3.11"
-          - conda-version: "22.9"
-            python-version: "3.11"
           # Python 3.12
-          - conda-version: "4.14"
-            python-version: "3.12"
-          - conda-version: "22.9"
-            python-version: "3.12"
-          - conda-version: "22.11"
-            python-version: "3.12"
           - conda-version: "23.5"
             python-version: "3.12"
           - conda-version: "23.9"
             python-version: "3.12"
+          # Conda-Lock
+          - conda-version: "23.5"
+            conda-lock: "3"
+          - conda-version: "23.9"
+            conda-lock: "3"
+          - conda-version: "24.1"
+            conda-lock: "3"
+          - conda-version: "24.4"
+            conda-lock: "3"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -133,9 +132,9 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ $RUNNER_OS == 'Windows' ]; then
-            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
+            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
           else
-            source $HOME/miniconda/bin/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
+            source $HOME/miniconda/bin/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
           fi
       - name: py.test
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,10 +75,20 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         conda-version: ["23.5", "23.9", "24.1" , "24.4", "25.3"]
         conda-lock: ["2.5.6", "3"]
         exclude:
+          # Python 3.12
+          - conda-version: "23.5"
+            python-version: "3.13"
+          - conda-version: "23.9"
+            python-version: "3.13"
+          - conda-version: "24.1"
+            python-version: "3.13"
+          - conda-version: "24.4"
+            python-version: "3.13"
+
           # Python 3.12
           - conda-version: "23.5"
             python-version: "3.12"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,6 +120,7 @@ jobs:
           fi
           chmod +x conda.exe
           ./conda.exe config --set auto_update_conda false
+          ./conda.exe config --prepend channels conda-forge
           ./conda.exe clean -ay
           ./conda.exe info
       - name: Setup miniconda
@@ -142,9 +143,9 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ $RUNNER_OS == 'Windows' ]; then
-            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
+            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forgge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
           else
-            source $HOME/miniconda/bin/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
+            source $HOME/miniconda/bin/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
           fi
       - name: py.test
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         conda-version: ["23.5", "23.9", "24.1" , "24.4", "25.3"]
-        conda-lock: ["2.5.6", "3"]
+        conda-lock: ["2", "3"]
         exclude:
           # Python 3.12
           - conda-version: "23.5"
@@ -126,7 +126,7 @@ jobs:
       - name: Setup miniconda
         shell: bash -l {0}
         run: |
-          ./conda.exe create -p $HOME/miniconda conda=${{ matrix.conda-version }} python=${{ matrix.python-version }}
+          ./conda.exe create -q -p $HOME/miniconda conda=${{ matrix.conda-version }} python=${{ matrix.python-version }}
       - name: Install Libmamba
         shell: bash -l {0}
         run: |
@@ -143,9 +143,9 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ $RUNNER_OS == 'Windows' ]; then
-            source $HOME/miniconda/Scripts/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
+            source $HOME/miniconda/Scripts/activate root && conda env update -q -f etc/test-environment.cl${{matrix.conda-lock}}.yml -p $HOME/miniconda && $HOME/miniconda/Scripts/pip install --no-deps .
           else
-            source $HOME/miniconda/bin/activate root && conda env update -f etc/test-environment.yml -p $HOME/miniconda && conda install conda-forge::conda-lock=${{matrix.conda-lock}} -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
+            source $HOME/miniconda/bin/activate root && conda env update -q -f etc/test-environment.cl${{matrix.conda-lock}}.yml -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
           fi
       - name: py.test
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -147,6 +147,14 @@ jobs:
           else
             source $HOME/miniconda/bin/activate root && conda env update -q -f etc/test-environment.cl${{matrix.conda-lock}}.yml -p $HOME/miniconda && $HOME/miniconda/bin/pip install --no-deps .
           fi
+      - name: List dependencies
+        shell: bash -l {0}
+        run: |
+          if [ $RUNNER_OS == 'Windows' ]; then
+            source $HOME/miniconda/Scripts/activate root && conda list
+          else
+            source $HOME/miniconda/bin/activate root && conda list
+          fi
       - name: py.test
         shell: bash -l {0}
         env:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     {% endfor %}
   run:
     - python {{ project['requires-python'] }}
-    - conda-lock >=2.5.6,<3
+    - conda-lock >=2.5.6
     - lockfile
     - pexpect
     - ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - conda-lock>=2.5.6,<3
+  - conda-lock>=2.5.6
   - pip:
     - -e ".[dev]"

--- a/etc/build-environment.yml
+++ b/etc/build-environment.yml
@@ -1,6 +1,5 @@
 name: build-conda-project
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - conda

--- a/etc/test-environment.cl2.yml
+++ b/etc/test-environment.cl2.yml
@@ -2,7 +2,7 @@ name: test-conda-project
 channels:
   - conda-forge
 dependencies:
-  - conda-lock>=2.5.6
+  - conda-lock=2.5.8
   - pexpect
   - lockfile
   - ruamel.yaml

--- a/etc/test-environment.cl3.yml
+++ b/etc/test-environment.cl3.yml
@@ -1,0 +1,16 @@
+name: test-conda-project
+channels:
+  - conda-forge
+dependencies:
+  - conda-lock=3
+  - pexpect
+  - lockfile
+  - ruamel.yaml
+  - pydantic
+  - pytest
+  - pytest-cov
+  - pytest-mock
+  - shellingham
+  - python-dotenv
+  - fsspec
+  - python-libarchive-c

--- a/etc/test-environment.yml
+++ b/etc/test-environment.yml
@@ -2,7 +2,7 @@ name: test-conda-project
 channels:
   - conda-forge
 dependencies:
-  - conda-lock>=2.5.6,<3
+  - conda-lock>=2.5.6
   - pexpect
   - lockfile
   - ruamel.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "conda-lock >=2.5.6,<3",
+    "conda-lock >=2.5.6",
     "lockfile",
     "pexpect",
     "ruamel.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Archiving :: Packaging",

--- a/src/conda_project/_conda_lock.py
+++ b/src/conda_project/_conda_lock.py
@@ -21,8 +21,8 @@ def is_conda_lock_3() -> bool:
     return parse(conda_lock.__version__) >= parse("3.0.0")
 
 
-if is_conda_lock_3():
-    from conda_lock.lookup import DEFAULT_MAPPING_URL
+if is_conda_lock_3():  # pragma: no cover
+    from conda_lock.lookup import DEFAULT_MAPPING_URL  # pragma: no cover
 
 
 def make_lock_spec(
@@ -32,8 +32,8 @@ def make_lock_spec(
     platform_overrides: Optional[Sequence[str]] = None,
     required_categories: Optional[AbstractSet[str]] = None,
 ) -> LockSpecification:
-    if is_conda_lock_3():
-        spec = _make_lock_spec(
+    if is_conda_lock_3():  # pragma: no cover
+        spec = _make_lock_spec(  # type: ignore
             src_files=src_files,
             channel_overrides=channel_overrides,
             pip_repository_overrides=pip_repository_overrides,
@@ -42,7 +42,7 @@ def make_lock_spec(
             mapping_url=DEFAULT_MAPPING_URL,
         )
         return spec
-    else:
+    else:  # pragma: no cover
         spec = _make_lock_spec(  # type: ignore
             src_files=src_files,
             channel_overrides=channel_overrides,
@@ -74,8 +74,8 @@ def make_lock_files(
     with_cuda: Optional[str] = None,
     strip_auth: bool = False,
 ):
-    if is_conda_lock_3():
-        _make_lock_files(
+    if is_conda_lock_3():  # pragma: no cover
+        _make_lock_files(  # pragma: no cover
             conda=conda,
             src_files=src_files,
             lockfile_path=lockfile_path,
@@ -95,8 +95,8 @@ def make_lock_files(
             strip_auth=strip_auth,
             mapping_url=DEFAULT_MAPPING_URL,
         )
-    else:
-        _make_lock_files(  # type: ignore
+    else:  # pragma: no cover
+        _make_lock_files(  # type: ignore; pragma: no cover
             conda=conda,
             src_files=src_files,
             lockfile_path=lockfile_path,
@@ -118,9 +118,9 @@ def make_lock_files(
 
 
 def lock_spec_content_hashes(spec: LockSpecification) -> Dict[str, str]:
-    if is_conda_lock_3():
-        return spec.content_hash(
+    if is_conda_lock_3():  # pragma: no cover
+        return spec.content_hash(  # pragma: no cover
             virtual_package_repo=default_virtual_package_repodata()
         )
-    else:
-        return spec.content_hash()
+    else:  # pragma: no cover
+        return spec.content_hash()  # pragma: no cover

--- a/src/conda_project/_conda_lock.py
+++ b/src/conda_project/_conda_lock.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2022-2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+from pathlib import Path
+from typing import AbstractSet, Dict, List, Optional, Sequence
+
+import conda_lock
+from conda_lock.conda_lock import (
+    MetadataOption,
+    PathLike,
+    TKindAll,
+    default_virtual_package_repodata,
+)
+from conda_lock.conda_lock import make_lock_files as _make_lock_files
+from conda_lock.conda_lock import make_lock_spec as _make_lock_spec
+from conda_lock.models.lock_spec import LockSpecification
+from packaging.version import parse
+
+
+def is_conda_lock_3() -> bool:
+    return parse(conda_lock.__version__) >= parse("3.0.0")
+
+
+if is_conda_lock_3():
+    from conda_lock.lookup import DEFAULT_MAPPING_URL
+
+
+def make_lock_spec(
+    src_files: List[Path],
+    channel_overrides: Optional[Sequence[str]] = None,
+    pip_repository_overrides: Optional[Sequence[str]] = None,
+    platform_overrides: Optional[Sequence[str]] = None,
+    required_categories: Optional[AbstractSet[str]] = None,
+) -> LockSpecification:
+    if is_conda_lock_3():
+        spec = _make_lock_spec(
+            src_files=src_files,
+            channel_overrides=channel_overrides,
+            pip_repository_overrides=pip_repository_overrides,
+            platform_overrides=platform_overrides,
+            required_categories=required_categories,
+            mapping_url=DEFAULT_MAPPING_URL,
+        )
+        return spec
+    else:
+        spec = _make_lock_spec(  # type: ignore
+            src_files=src_files,
+            channel_overrides=channel_overrides,
+            pip_repository_overrides=pip_repository_overrides,
+            platform_overrides=platform_overrides,
+            required_categories=required_categories,
+            virtual_package_repo=default_virtual_package_repodata(),
+        )
+        return spec
+
+
+def make_lock_files(
+    *,
+    conda: PathLike,
+    src_files: List[Path],
+    kinds: Sequence[TKindAll],
+    lockfile_path: Optional[Path] = None,
+    platform_overrides: Optional[Sequence[str]] = None,
+    channel_overrides: Optional[Sequence[str]] = None,
+    virtual_package_spec: Optional[Path] = None,
+    update: Optional[Sequence[str]] = None,
+    include_dev_dependencies: bool = True,
+    filename_template: Optional[str] = None,
+    filter_categories: bool = False,
+    extras: Optional[AbstractSet[str]] = None,
+    check_input_hash: bool = False,
+    metadata_choices: AbstractSet[MetadataOption] = frozenset(),
+    metadata_yamls: Sequence[Path] = (),
+    with_cuda: Optional[str] = None,
+    strip_auth: bool = False,
+):
+    if is_conda_lock_3():
+        _make_lock_files(
+            conda=conda,
+            src_files=src_files,
+            lockfile_path=lockfile_path,
+            kinds=kinds,
+            platform_overrides=platform_overrides,
+            channel_overrides=channel_overrides,
+            check_input_hash=check_input_hash,
+            metadata_choices=metadata_choices,
+            virtual_package_spec=virtual_package_spec,
+            update=update,
+            include_dev_dependencies=include_dev_dependencies,
+            filename_template=filename_template,
+            filter_categories=filter_categories,
+            extras=extras,
+            metadata_yamls=metadata_yamls,
+            with_cuda=with_cuda,
+            strip_auth=strip_auth,
+            mapping_url=DEFAULT_MAPPING_URL,
+        )
+    else:
+        _make_lock_files(  # type: ignore
+            conda=conda,
+            src_files=src_files,
+            lockfile_path=lockfile_path,
+            kinds=kinds,
+            platform_overrides=platform_overrides,
+            channel_overrides=channel_overrides,
+            check_input_hash=check_input_hash,
+            metadata_choices=metadata_choices,
+            virtual_package_spec=virtual_package_spec,
+            update=update,
+            include_dev_dependencies=include_dev_dependencies,
+            filename_template=filename_template,
+            filter_categories=filter_categories,
+            extras=extras,
+            metadata_yamls=metadata_yamls,
+            with_cuda=with_cuda,
+            strip_auth=strip_auth,
+        )
+
+
+def lock_spec_content_hashes(spec: LockSpecification) -> Dict[str, str]:
+    if is_conda_lock_3():
+        return spec.content_hash(
+            virtual_package_repo=default_virtual_package_repodata()
+        )
+    else:
+        return spec.content_hash(
+            virtual_package_repo=default_virtual_package_repodata()
+        )

--- a/src/conda_project/_conda_lock.py
+++ b/src/conda_project/_conda_lock.py
@@ -123,6 +123,4 @@ def lock_spec_content_hashes(spec: LockSpecification) -> Dict[str, str]:
             virtual_package_repo=default_virtual_package_repodata()
         )
     else:
-        return spec.content_hash(
-            virtual_package_repo=default_virtual_package_repodata()
-        )
+        return spec.content_hash()

--- a/src/conda_project/conda.py
+++ b/src/conda_project/conda.py
@@ -23,13 +23,10 @@ import pexpect
 from conda_lock._vendor.conda.core.prefix_data import PrefixData, PrefixRecord
 from conda_lock._vendor.conda.models.channel import Channel
 from conda_lock._vendor.conda.utils import wrap_subprocess_call
-from conda_lock.conda_lock import (
-    default_virtual_package_repodata,
-    make_lock_spec,
-    parse_conda_lock_file,
-)
+from conda_lock.conda_lock import parse_conda_lock_file
 from conda_lock.lockfile.v2prelim.models import Lockfile
 
+from ._conda_lock import lock_spec_content_hashes, make_lock_spec
 from .exceptions import CondaProjectError
 from .project_file import EnvironmentYaml, UniqueOrderedList
 from .utils import Spinner, detect_shell, execvped, is_windows
@@ -190,7 +187,6 @@ def env_export(
             environment.yaml(requested)
             spec = make_lock_spec(
                 src_files=[requested],
-                virtual_package_repo=default_virtual_package_repodata(),
             )
 
             if full_export or empty:
@@ -216,7 +212,7 @@ def env_export(
                 ]
             )
             lock_content = parse_conda_lock_file(lock)
-            lock_content.metadata.content_hash = spec.content_hash()
+            lock_content.metadata.content_hash = lock_spec_content_hashes(spec)
             lock_content.metadata.sources = ["environment.yml"]
 
     return environment, lock_content

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -223,7 +223,7 @@ def test_conda_prefix_prefers_path(tmp_path, monkeypatch):
     prefix = conda_prefix("my-env")
     assert prefix == tmp_path / "my-env"
 
-    _ = call_conda(["env", "remove", "-n", "my-env"])
+    _ = call_conda(["env", "remove", "-yn", "my-env"])
 
 
 def test_conda_prefix_name_not_found(tmp_path, monkeypatch):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -276,7 +276,7 @@ def test_install_as_platform(project_directory_factory):
 
     project.default_environment.install(as_platform="dummy-platform")
 
-    with project.default_environment.prefix / "condarc" as f:
+    with (project.default_environment.prefix / "condarc").open() as f:
         env_condarc = YAML().load(f)
 
     assert env_condarc["subdir"] == "dummy-platform"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -283,7 +283,7 @@ def test_install_as_platform(project_directory_factory):
 
     project.default_environment.install(force=True)
 
-    with project.default_environment.prefix / "condarc" as f:
+    with (project.default_environment.prefix / "condarc").open() as f:
         env_condarc = YAML().load(f)
 
     assert env_condarc["subdir"] == "dummy-platform"


### PR DESCRIPTION
Here I've provided lite wrappers on functions whose signatures changed between version 2 and 3. The goal is to ensure that conda-project supports both versions for now.