### PR TITLE
Replace pkg_resources Requirement parsing

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - python {{ project['requires-python'] }}
     - conda-lock >=2.5.6
     - lockfile
+    - packaging
     - pexpect
     - ruamel.yaml
     - pydantic
@@ -37,7 +38,6 @@ requirements:
     - python-dotenv
     - fsspec
     - python-libarchive-c
-    - setuptools
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "conda-lock >=2.5.6",
     "lockfile",
+    "packaging",
     "pexpect",
     "ruamel.yaml",
     "pydantic",
@@ -42,7 +43,6 @@ dependencies = [
     "python-dotenv",
     "fsspec",
     "libarchive-c",
-    "setuptools"
 ]
 
 [tool.hatch.version]

--- a/src/conda_project/project_file.py
+++ b/src/conda_project/project_file.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, OrderedDict, TextIO, Union
 
 from conda_lock._vendor.conda.models.match_spec import MatchSpec
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 from ruamel.yaml import YAML
 
 try:  # pragma: no cover

--- a/tests/test_project_file.py
+++ b/tests/test_project_file.py
@@ -270,6 +270,14 @@ def test_env_extend_pip_dependencies():
     ]
 
 
+def test_env_pip_requirement_names():
+    env = EnvironmentYaml(
+        dependencies=["python=3.10", "pip", {"pip": ["pydantic[email,dotenv]<2"]}]
+    )
+
+    assert [dep.name for dep in env.pip_requirements] == ["pydantic"]
+
+
 def test_env_add_dependencies_empty_channels():
     env = EnvironmentYaml(dependencies=["python=3.10", "numpy"])
 


### PR DESCRIPTION
## Summary
- replace `pkg_resources.Requirement` with `packaging.requirements.Requirement`
- declare `packaging` as the runtime dependency for PyPI and conda packages
- remove the runtime `setuptools` dependency that only supplied `pkg_resources`
- add regression coverage for pip requirement name parsing with extras

Fixes #190.
Refs #189.

## Validation
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `rg -n pkg_resources|setuptools src tests pyproject.toml conda.recipe`
- `rg -n Requirement\(|packaging src tests pyproject.toml conda.recipe`

Not run locally.